### PR TITLE
Fail the tests if there are lint warnings

### DIFF
--- a/script/test-prose
+++ b/script/test-prose
@@ -36,6 +36,9 @@ var options = {
 
     // FIXME: Eventually remove these
     "maximum-heading-length": 80,
+    "no-literal-urls": false,
+    "no-inline-padding": false,
+    "no-missing-blank-lines": false,
   },
   "readability": {
     "age": 18


### PR DESCRIPTION
This will fail CI if there are any warnings from `script/test-prose`. Right now this script just lints the markdown, but eventually it will also enforce style guide rules.

I've temporarily disabled a few rules and will begin enabling them in subsequent PRs.
