### PR TITLE
Add linting for sentence-spacing

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "retext-english": "^2.0.0",
     "retext-equality": "^2.3.2",
     "retext-readability": "^2.0.0",
+    "retext-sentence-spacing": "^1.0.0",
     "retext-simplify": "^2.0.0",
     "to-vfile": "^1.0.0",
     "unified": "^4.1.2",

--- a/script/test-prose
+++ b/script/test-prose
@@ -8,6 +8,8 @@ var parse = require('remark-parse');
 var lint = require('remark-lint');
 var remark2retext = require('remark-retext');
 var stringify = require('remark-stringify');
+var english = require('retext-english');
+var sentenceSpacing = require('retext-sentence-spacing');
 
 // Util stuff
 var report = require('vfile-reporter');
@@ -55,12 +57,13 @@ async.map(ignore.filter(glob.sync("**/*.md")), function(file, callback) {
     unified()
       .use(parse)
       .use(lint, options["lint"])
-      // .use(remark2retext, unified()
-      //   .use(require('retext-english'))
-      //   .use(require('retext-simplify'), options["simplify"])
-      //   .use(require('retext-equality'))
-      //   .use(require('retext-readability'), options["readability"])
-      // )
+      .use(remark2retext, unified()
+        .use(english)
+        .use(sentenceSpacing, {preferred: 1})
+        // .use(require('retext-simplify'), options["simplify"])
+        // .use(require('retext-equality'))
+        // .use(require('retext-readability'), options["readability"])
+      )
       .use(stringify)
       .process(contents.toString(), options["remark"], function (err, result) {
           result.filename = file;


### PR DESCRIPTION
This change re-introduces `remark2retext` for linting natural
language, initially with the `remark-sentence-spacing` plugin.
This new behavior checks for spacing between sentences, preferring
one space.

Continuation from GH-36. Thanks @bkeepers for the idea! :)

Oh: the object at https://github.com/github/open-source-handbook/compare/github:5561a02...github:a344a3c#diff-32f407df32dad8e987e9c6f3d16f27a7R62 can also be omitted (it’s the default), but maybe it adds some clarity to have it in here as well.
