### PR TITLE
Table of contents for each article

### DIFF
--- a/getting-started/branding.md
+++ b/getting-started/branding.md
@@ -9,6 +9,9 @@ Branding may sound like a waste of time. After all there, are plenty of popular 
 
 But branding is more than a flashy logo or catchy project name. It's about how you talk about your project and who you reach with your message. Here are a few things you'll want to think about before you launch.
 
+* TOC
+{:toc}
+
 ## Choosing the right name
 
 Pick a name that is easy to remember and, ideally, gives some idea of what the project does. For example, [Sentry](https://github.com/getsentry/sentry) monitors apps for crash reporting, and [Thin](https://github.com/macournoyer/thin) is a fast and simple Ruby web server.

--- a/getting-started/legal.md
+++ b/getting-started/legal.md
@@ -9,12 +9,8 @@ Thankfully, you don't have to start from scratch. This section will make sure yo
 
 **(Do we need a legal disclaimer for this piece?)**
 
-## Table of Contents
-
-1. [Why does my project need an open source license?](#why-does-my-project-need-an-open-source-license)
-2. [Which open source license is appropriate for my project?](#which-open-source-license-is-appropriate-for-my-project)
-3. [Does my project need an additional contributor agreement?](#does-my-project-need-an-additional-contributor-agreement)
-4. [What does my company's legal team need to know?](#what-does-my-companys-legal-team-need-to-know)
+* TOC
+{:toc}
 
 ## Why does my project need an open source license?
 

--- a/getting-started/preparing.md
+++ b/getting-started/preparing.md
@@ -14,6 +14,9 @@ Every open source project should include the following:
 
 As a maintainer, these components will help you communicate expectations, manage contributions, protect your, contributors', and users' legal rights, and make sure that you and your contributors have a positive experience. The more you can document for your readers up front, the less work you'll have to do later on.
 
+* TOC
+{:toc}
+
 ## Choosing a license
 
 An open source license guarantees that others can use, copy, modify, and contribute back to your project without repercussions. It also protects you from any sticky legal situations.

--- a/getting-started/setting-expectations.md
+++ b/getting-started/setting-expectations.md
@@ -7,6 +7,9 @@ There are many reasons to open source a project. It's a good idea to figure out 
 
 In this section, we'll help you think through a few important questions about the goals of your project.
 
+* TOC
+{:toc}
+
 ## Define your goals
 
 Let's start by defining your goals. Simply put: _why are you open sourcing this project?_

--- a/marketing/building-community.md
+++ b/marketing/building-community.md
@@ -5,6 +5,9 @@ next: marketing/measuring.md
 
 You've launched your project, you're spreading the word, and people are checking out your project. Awesome! Now, how do you get them to stick around? In this section, we'll discuss ways to encourage people to use, contribute to, and evangelize your project.
 
+* TOC
+{:toc}
+
 ## Give your community a place to congregate
 
 There are two reasons to give your community a place to congregate.

--- a/marketing/measuring.md
+++ b/marketing/measuring.md
@@ -5,6 +5,9 @@ next: sustaining/index.md
 
 Your project is starting to grow. 🌱 Well, you think it's growing. Is it growing? In this section, we'll talk about how to measure and track the success of your open source project.
 
+* TOC
+{:toc}
+
 ## Discoverability
 
 Before anybody can use or contribute back to your project, they first need to know it exists. The first question you'll want to ask yourself, then, is: _are people finding my project?_

--- a/marketing/spreading-word.md
+++ b/marketing/spreading-word.md
@@ -7,6 +7,9 @@ You've just published your project–what's next? It's time to tell everybody ab
 
 In this section, we'll go through some of the most effective ways that people promote their open source projects. But before we do, let's start with a few tips that will help you make the most of your outreach.
 
+* TOC
+{:toc}
+
 ## Be able to convey who you are (and why it matters)
 
 Before you start the hard work of promoting your project, you should be able to explain why your project is different or interesting. Why should someone get excited about your work? Answering this question for yourself will make it easier to convince others.

--- a/sustaining/best-practices.md
+++ b/sustaining/best-practices.md
@@ -9,6 +9,9 @@ As you've probably noticed, a major part of maintaining an active open source pr
 
 In this section, we'll talk about how to set up your projects in a way that helps you maintain your sanity.
 
+* TOC
+{:toc}
+
 ## Know yourself and your needs
 
 Remember way back, before you launched your project, [when you wrote down](../../getting-started/setting-expectations) your expectations? It's time to revisit that document now. Remind yourself why you're doing this work and what you want to get out of open sourcing your project. Has anything changed?

--- a/sustaining/healthy-communities.md
+++ b/sustaining/healthy-communities.md
@@ -14,6 +14,9 @@ A casual contributor may not have time to get fully up to speed with your projec
 
 Here are some ways you can empower your biggest fans to run with the work they're excited about.
 
+* TOC
+{:toc}
+
 ## Meet contributors where they're at
 
 Good documentation is important to give casual contributors the context they need. Make sure people know what the goal of your project is and whether there are contributions you categorically won't accept.

--- a/sustaining/leadership.md
+++ b/sustaining/leadership.md
@@ -7,14 +7,8 @@ Your project is growing, people are engaged, and you're committed to keeping thi
 
 In this section, we'll answer some commonly asked questions about leadership and governance for open source projects.
 
-## Table of Contents
-
-1. [What are some of the common governance structures for open source projects?](#what-are-some-of-the-common-governance-structures-for-open-source-projects)
-2. [Do I need governance docs when I launch my project?](#do-i-need-governance-docs-when-i-launch-my-project)
-3. [When should I give someone commit access?](#when-should-i-give-someone-commit-access)
-4. [What are some leadership roles or responsibilities that projects use?](#what-are-some-leadership-roles-or-responsibilities-that-projects-use)
-5. [How do I formalize leadership roles in my project?](#how-do-i-formalize-leadership-roles-in-my-project)
-6. [Do I need a legal entity to support my project?](#do-i-need-a-legal-entity-to-support-my-project)
+* TOC
+{:toc}
 
 ## What are some of the common governance structures for open source projects?
 

--- a/troubleshooting/burnout.md
+++ b/troubleshooting/burnout.md
@@ -6,6 +6,9 @@ Open source work once brought you joy. Maybe now it's starting to make you feel 
 
 Burnout is a real and pervasive issue in open source work, especially among maintainers. Let's talk about how to make things better.
 
+* TOC
+{:toc}
+
 ## Clearly communicate your limits
 
 Most people who come across your project don't know anything about you or your circumstances. They may even think that you get paid to work on the project, especially if it's something they regularly use and depend on.

--- a/troubleshooting/conduct.md
+++ b/troubleshooting/conduct.md
@@ -4,6 +4,9 @@ title: Enforcing your code of conduct
 
 Your code of conduct helps create a healthy and constructive social atmosphere for your project's community. Sometimes, despite your best efforts, somebody will do something that violates this code. In this section, we'll talk about how to address negative or harmful behavior in your project's community.
 
+* TOC
+{:toc}
+
 ## Write down how you'll enforce your code of conduct
 
 Ideally, you've explained how your code of conduct will be enforced **_before_** a violation occurs. There are several reasons for this:

--- a/troubleshooting/contributions.md
+++ b/troubleshooting/contributions.md
@@ -6,6 +6,9 @@ As a maintainer of an open source project, you'll inevitably receive contributio
 
 Regardless of the reason, here are some strategies to tactfully handle contributions that don't meet your project's standards.
 
+* TOC
+{:toc}
+
 ## Say something!
 
 If you receive a contribution you don't want to accept, your first reaction might be to ignore it or pretend you didn't see it. Doing so could hurt the other person's feelings and even demotivate other potential contributors in your community.

--- a/troubleshooting/finding-consensus.md
+++ b/troubleshooting/finding-consensus.md
@@ -8,6 +8,9 @@ As your project becomes more popular, more people will take interest in the deci
 
 For the most part, if you've cultivated a friendly, respectful community and documented your processes openly, you and your community should be able to reach a resolution. But sometimes you run into an issue that's a little bit harder to address. Here are some strategies to reach consensus.
 
+* TOC
+{:toc}
+
 ## Set the bar for kindness
 
 When your community is grappling with a difficult issue, tempers may rise. People may become angry or frustrated and take it out on one another, or on you.


### PR DESCRIPTION
This adds the [{:toc}](http://kramdown.gettalong.org/converter/html.html#toc) tag for articles with multiple headings.

Closes #67 
/cc @benbalter 
