### PR TITLE
Be more explicit about markdown syntax

### DIFF
--- a/script/test-prose
+++ b/script/test-prose
@@ -30,22 +30,24 @@ var options = {
 
   // https://github.com/wooorm/remark-lint/blob/master/doc/rules.md
   "lint": {
-    "list-item-indent": "space",    // As the gods intended.
-    "maximum-line-length": false,   // turn off line length linting
+    // Headings
+    "heading-style": "atx",             // ## Headings
+    "first-heading-level": 2,           // Page title is h1, so start with h2
     "no-heading-punctuation": false,
+    "maximum-heading-length": 80,       // FIXME: Eventually remove this
+
+    // Lists
+    "list-item-indent": "space",        // As the gods intended.
     "list-item-spacing": false,
-    "first-heading-level": 2,       // Page title is h1, so start with h2
-    "no-missing-blank-lines": {"exceptTightLists": true},
-    "emphasis-marker": "_",
-    "strong-marker": "*",
     "unordered-list-marker-style": "*",
     "ordered-list-marker-style": ".",
+
+    // Misc
+    "maximum-line-length": false,   // turn off line length linting
+    "emphasis-marker": "_",
+    "strong-marker": "*",
     "blockquote-indentation": 2,
-    "heading-style": "atx",
-
-
-    // FIXME: Eventually remove these
-    "maximum-heading-length": 80,
+    "no-missing-blank-lines": {"exceptTightLists": true},
   },
   "readability": {
     "age": 18


### PR DESCRIPTION
ec713a9 makes the settings for a few rules explicit, instead of relying on consistency within each document.  f58f120 just groups some of the rules.
