### PR TITLE
Before you get started->Getting started

### DIFF
--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -1,5 +1,5 @@
 ---
-title: Before you Get Started
+title: Getting Started
 next: getting-started/setting-expectations.md
 contents:
   - getting-started/setting-expectations.md


### PR DESCRIPTION
Remove incongruity with articles in section that clearly come after "before" you get started, noted in https://github.com/github/open-source-handbook/issues/49#issuecomment-241503326
