### PR TITLE
Create custom domain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+opensource.guide


### PR DESCRIPTION
We need a custom domain for the handbook. [As discussed](https://github.slack.com/archives/open-source-handbook/p1472593273000115), we're going with  http://opensource.guide.

cc @shawndavenport could we get this domain purchased and set up?
