### PR TITLE
Fix lint failures

### DIFF
--- a/getting-started/branding.md
+++ b/getting-started/branding.md
@@ -16,7 +16,7 @@ But branding is more than a flashy logo or catchy project name. It's about how y
 
 Pick a name that is easy to remember and, ideally, gives some idea of what the project does. For example, [Sentry](https://github.com/getsentry/sentry) monitors apps for crash reporting, and [Thin](https://github.com/macournoyer/thin) is a fast and simple Ruby web server.
 
-If you're building upon an existing project, using their name as a prefix can help clarify what your project does. For example, [node-fetch](https://github.com/bitinn/node-fetch) is a module that brings 'window.fetch' to Node.js.
+If you're building upon an existing project, using their name as a prefix can help clarify what your project does. For example, [node-fetch](https://github.com/bitinn/node-fetch) is a module that brings `window.fetch` to Node.js.
 
 Consider clarity above all. Puns are fun, but remember that some jokes might not translate to other cultures or people with different experiences from you. For example, some of your potential users might be company employees; you don't want to make them uncomfortable when they explain your project at work!
 

--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -19,21 +19,25 @@ One more thing: we can give you advice on running an open source project, but we
 {:toc}
 
 ## You're open sourcing a project for the first time
+
 You've heard a lot about this "open source" thing and you'd like to release a project for the first time.
 
 If you're worried about getting things right, check out ["Preparing for launch"](preparing) for a quickstart guide, as well as the [Marketing](../marketing) section.
 
 ## You've open sourced projects before, but you'd like to sharpen your skills
+
 You currently maintain a few open source projects. You understand the basic mechanics, but there are some things you think you could do better.
 
 If you're hoping to improve your skills as a maintainer, take a look at the [Sustaining Growth](../sustaining) and [Troubleshooting](../troubleshooting) sections.
 
 ## You're trying to build a large community project
-For you, the best part about open source is *collaboration*. You're excited to work on a project with people from all over the world.
+
+For you, the best part about open source is _collaboration_. You're excited to work on a project with people from all over the world.
 
 If community is important to you, keep an eye out for resources such as ["Building a community"](../marketing/building-community) and ["Sustaining healthy communities"](../sustaining/healthy-communities).
 
 ## You're a company open sourcing a project
+
 Your company is about to open source a previously internal project. You want to do it without breaking any laws or upsetting anyone who will interact with your project.
 
 If you're worried about making lawyers happy, ["The legal side of open source"](legal) and ["Leadership & governance"](../sustaining/leadership) can help you with trademark, license, and other company matters.

--- a/getting-started/preparing.md
+++ b/getting-started/preparing.md
@@ -71,6 +71,7 @@ If you [place your CONTRIBUTING file in your project's repository](https://help.
 Finally, a code of conduct helps set ground rules for behavior of your project's participants. This is especially valuable if you're launching an open source project for a community or company. We recommend placing a CODE_OF_CONDUCT file in your project's root directory.
 
 In addition to communicating your expectations, you should describe the following:
+
 * Where your code of conduct takes effect (only on issues and pull requests, or related community activities like events?)
 * Who the code of conduct applies to (community members and maintainers, but what about sponsors?)
 * What happens if someone violates the code of conduct

--- a/getting-started/setting-expectations.md
+++ b/getting-started/setting-expectations.md
@@ -11,6 +11,7 @@ In this section, we'll help you think through a few important questions about th
 {:toc}
 
 ## Your first time
+
 If you've never open sourced a project before, you might be nervous about whether your work is good enough, what people will say, or whether anyone will notice at all. If this sounds like you, don't worry!
 
 Open source work is like any other creative activity, such as writing or painting. It might feel scary to share your work with the world for the first time, but the only way to get better is to practice. If you're still on the fence, [check out these reasons](http://www.huffingtonpost.com/bianca-bass/why-you-should-write-even_b_9331252.html) why people write, even when they don't have an audience.

--- a/marketing/measuring.md
+++ b/marketing/measuring.md
@@ -7,7 +7,7 @@ Your project is starting to grow. 🌱 Well, you think it's growing. Is it growi
 
 One caveat: popularity doesn't matter for every open source project. Everybody gets into open source for different reasons. If [your goal](../../getting-started/setting-expectations) was to show off your portfolio work, be transparent about your code, or just have fun, don't feel pressured to grow your project through the metrics outlined below.
 
-If you *are* interested in growing your project, the following metrics will give you a framework for analyzing and tracking your progress.
+If you _are_ interested in growing your project, the following metrics will give you a framework for analyzing and tracking your progress.
 
 * TOC
 {:toc}
@@ -55,7 +55,7 @@ Here are a few types of contributor metrics you may want to regularly track:
 * **First time vs. repeat contributors:** Helps you track whether you're getting new contributors in. Without new contributors, your project's community can become stagnant.
 
 * **Number of open issues and open pull requests:** If these numbers get too high, you might need help with issue triaging and code reviews.
-* **Number of *opened* issues and *opened* pull requests:** Opened issues means somebody cares enough about your project to open an issue. If that number increases over time, it suggests people are interested in your project.
+* **Number of _opened_ issues and _opened_ pull requests:** Opened issues means somebody cares enough about your project to open an issue. If that number increases over time, it suggests people are interested in your project.
 
 * **Types of contributions:** For example, commits, fixing typos or bugs, or commenting on an issue.
 

--- a/troubleshooting/burnout.md
+++ b/troubleshooting/burnout.md
@@ -37,7 +37,7 @@ Taking breaks applies to more than just vacations, too. If you don't want to do 
 
 Sometimes, someone who uses your project really wants a solution that you simply don't have the bandwidth to build. Offering APIs and customization hooks can help others meet their own needs, without having to modify the source directly. @orta [describes his strategy](http://artsy.github.io/blog/2016/07/03/handling-big-projects/) for building open source "defensively" in the iOS ecosystem:
 
-> It's almost inevitable that once a project becomes big, maintainers have to become a lot more conservative about how they introduce new code. You become good at saying 'no', but a lot of people have legitimate needs. So, instead you end up converting your tool into a platform.
+> It's almost inevitable that once a project becomes big, maintainers have to become a lot more conservative about how they introduce new code. You become good at saying "no", but a lot of people have legitimate needs. So, instead you end up converting your tool into a platform.
 >
 > Some of the most interesting ideas in the CocoaPods ecosystem come from plugins.
 >


### PR DESCRIPTION
This fixes the lint failures. I know they're [pedantic](https://speakerdeck.com/bkeepers/open-source-principles-for-internal-engineering-teams?slide=34), but I think it'll be important to enforce style once we open this up to the public.
