### PR TITLE
Move goals to README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,30 +2,16 @@
 
 Thanks for checking out the Open Source Handbook! We're excited to hear and learn from you. Your experiences will benefit others who are reading and using this Handbook.
 
-We've put together the following guidelines to: 1) communicate the goals of this project and 2) help you figure out where you can best be helpful.
+We've put together the following guidelines to help you figure out where you can best be helpful.
 
 ## Table of Contents
-1. [Goals of this project](#goals-of-this-project)
-2. [Types of contributions we're looking for](#types-of-contributions-were-looking-for)
-3. [Ground rules & expectations](#ground-rules--expectations)
-4. [How to contribute](#how-to-contribute)
-5. [Setting up your environment](#setting-up-your-environment)
-6. [Contribution review process](#contribution-review-process)
-7. [Community](#community)
 
-## Goals of this project
-
-We created this Handbook for individuals, communities, and companies that want to successfully run and maintain an open source project. The content was originally created and curated by GitHub, along with input from outside community reviewers, but it is not specific to GitHub products.
-
-Here are some guiding principles for the Handbook:
-
-* **Approachability:** Don't assume reader has prior knowledge
-* **Brevity:** Keep it simple, link to outside content for deeper dives
-* **Curation:** Amplify community best practices vs. any individual's point of view
-
-This Handbook is a jumping off point for people who want to learn how to run an open source project. It should give readers enough information to get started, but it doesn't attempt to answer everything in detail.
-
-This Handbook also aggregates community best practices, *not* what GitHub (or any other individual or entity) thinks is best. Therefore, we try to use examples and quotations from others to illustrate our points. Many sections also link to "Further Reading" at the end, to surface relevant writing and perspectives that live elsewhere on the web.
+0. [Types of contributions we're looking for](#types-of-contributions-were-looking-for)
+0. [Ground rules & expectations](#ground-rules--expectations)
+0. [How to contribute](#how-to-contribute)
+0. [Setting up your environment](#setting-up-your-environment)
+0. [Contribution review process](#contribution-review-process)
+0. [Community](#community)
 
 ## Types of contributions we're looking for
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,20 @@
 # Open Source Handbook
 
-This handbook is a collection of resources to help individuals, communities, and companies sustainably embrace open source software. It explains not only how to accomplish a task, but why you'd want to, and how that task fits into the larger story of consuming, contributing to, and producing open source software.
+a handbook for open source creators. **[Check it out…](http://opensource.guide/)**
 
-This handbook aims to foster healthy open source communities, and provide a canonical place for the community to discuss and codify best practices into highly-approachable resources.
+## Goals
 
-### [Get Started](https://github.github.io/open-source-handbook/)
+This handbook is a collection of resources for individuals, communities, and companies that want to successfully run and maintain an open source project. The content was originally created and curated by GitHub, along with input from outside community reviewers, but it is not specific to GitHub products.
+
+It follows these guiding principles:
+
+* **Approachability:** Don't assume reader has prior knowledge
+* **Brevity:** Keep it simple, link to outside content for deeper dives
+* **Curation:** Amplify community best practices vs. any individual's point of view
+
+This Handbook is a jumping off point for people who want to learn how to run an open source project. It should give readers enough information to get started, but it doesn't attempt to answer everything in detail.
+
+This Handbook also aggregates community best practices, *not* what GitHub (or any other individual or entity) thinks is best. Therefore, we try to use examples and quotations from others to illustrate our points. Many sections also link to "Further Reading" at the end, to surface relevant writing and perspectives that live elsewhere on the web.
 
 ## Contributing
 


### PR DESCRIPTION
@nayafia I started working on a roadmap like we discussed, and then was looking at #101 and realized the content in `CONTRIBUTING.md` did a pretty good job of communicating what I think is important.

Thoughts about just moving that section to the README?

View: [README.md](https://github.com/github/open-source-handbook/blob/6455187dd09931023f3b523539647ed3e227b82e/README.md) | [CONTRIBUTING.md](https://github.com/github/open-source-handbook/blob/6455187dd09931023f3b523539647ed3e227b82e/CONTRIBUTING.md)
