### PR TITLE
[WIP] Add better SEO support

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,6 @@
 title: "Open Source Handbook"
+url: http://opensource.guide
+logo: /path/to/logo.png
 
 exclude:
   - bin


### PR DESCRIPTION
Applies to #122
- [x] Author information - Was already working
- [ ] Logo - Half done, I need to know where to pull the actual logo from
- [x] URL
- [ ] ~~Page excerpt~~ Done in #132 

It appears the page excerpt part is going to be problematic. Jekyll extracts an excerpt automatically and this is what the jekyll-seo-tag gem relies on. The problem seems to be that Jekyll only extracts that excerpt on blog posts. Since all of the content in this site are normal pages, it isn't constructing the excerpt.
