### PR TITLE
Add support for alternate nav text

### DIFF
--- a/_includes/contents.html
+++ b/_includes/contents.html
@@ -9,7 +9,7 @@
   {% assign subpage = site.pages | where: "path", path | first %}
   <li{% if page.url contains subpage.url %} class="selected"{% endif %}>
     <a class="d-block {% if page.url == subpage.url %} current{% endif %}"
-      href="{{ subpage.url | prepend: site.baseurl }}">{{ subpage.title }}</a>
+      href="{{ subpage.url | prepend: site.baseurl }}">{% if subpage.nav == nil %}{{ subpage.title }}{% else %}{{ subpage.nav }}{% endif %}</a>
     {% if subpage.contents %}
       {% include contents.html item=subpage %}
     {% endif %}


### PR DESCRIPTION
For SEO purposes we need verbose titles, but we still want the nav text to be succinct. This
adds support for an optional 'nav' value that can be added to the frontmatter.

This doesn't actually add those values, otherwise all the markdown files will conflict with #126

See #123
