### PR TITLE
Remove taupe background

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   {% include head.html %}
-  <body class="bg-taupe">
+  <body>
     <div class="site-wrapper">
       <div class="site-canvas">
         <div class="site-canvas-mask"></div>


### PR DESCRIPTION
We're going to be doing some work on the design in a couple weeks, but in the mean time, the taupe background on the text is grating on my nerves.

![](https://cloud.githubusercontent.com/assets/173/19040648/9a8687aa-894a-11e6-91cb-39b02daa418d.png)
