### PR TITLE
Rename repo to open-source-guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ We've put together the following guidelines to help you figure out where you can
 0. [Community](#community)
 
 ## Types of contributions we're looking for
-First and foremost, this project is a forum to discuss open source best practices, then document them in the guide when we've found consensus. Your first contribution might be starting a new conversation, or adding to an existing conversation, around best practices. You can do so under [Issues](https://github.com/github/open-source-handbook/issues).
+First and foremost, this project is a forum to discuss open source best practices, then document them in the guide when we've found consensus. Your first contribution might be starting a new conversation, or adding to an existing conversation, around best practices. You can do so under [Issues](https://github.com/github/open-source-guide/issues).
 
 There are also many ways you can contribute to the guide directly:
 
@@ -36,7 +36,7 @@ Before we get started, here are a few things we expect from you (and that you sh
 
 ## How to contribute
 
-If you'd like to contribute, start by searching through the [issues](https://github.com/github/open-source-handbook/issues) and [pull requests](https://github.com/github/open-source-handbook/pulls) to see whether someone else has raised a similar idea or question.
+If you'd like to contribute, start by searching through the [issues](https://github.com/github/open-source-guide/issues) and [pull requests](https://github.com/github/open-source-guide/pulls) to see whether someone else has raised a similar idea or question.
 
 If you don't see your idea listed, and you think it fits into the goals of this guide, do one of the following:
 * **If your contribution is minor,** such as a typo fix, you can make the change and open a pull request.
@@ -63,7 +63,7 @@ If you've been active on this project (such as writing helpful content, answerin
 
 ## Community
 
-Discussions about this guide take place on this repository's [Issues](https://github.com/github/open-source-handbook/issues) and [Pull Requests](https://github.com/github/open-source-handbook/pulls) sections. Anybody is welcome to join these conversations. There is also a [mailing list](
+Discussions about this guide take place on this repository's [Issues](https://github.com/github/open-source-guide/issues) and [Pull Requests](https://github.com/github/open-source-guide/pulls) sections. Anybody is welcome to join these conversations. There is also a [mailing list](
 http://eepurl.com/cecpnT) for regular updates.
 
 Wherever possible, do not take these conversations to private channels, including contacting the maintainers directly. Keeping communication public means everybody can benefit and learn from the conversation.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Our goal is for this project to reflect community best practices, so we'd love y
 Content is released under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/), which gives you permission to use content for almost any purpose but does not grant you any trademark permissions, so long as you note the license and give credit, such as follows:
 
 > Content based on
-> <a href="https://github.com/github/open-source-handbook">github.com/github/open-source-handbook</a>
+> <a href="https://github.com/github/open-source-guide">github.com/github/open-source-guide</a>
 > used under the
 > <a href="https://creativecommons.org/licenses/by/4.0/">CC-BY-4.0</a>
 > license.</a>

--- a/_config.yml
+++ b/_config.yml
@@ -37,7 +37,7 @@ gems:
 branch: gh-pages
 
 github:
-  repository_nwo: github/open-source-handbook
+  repository_nwo: github/open-source-guide
 
 twitter:
   username: github

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "open-source-handbook",
+  "name": "open-source-guide",
   "description": "This guide is a collection of resources to help individuals, communities, and companies sustainably embrace open source software. It explains not only how to accomplish a task, but why you'd want to, and how that task fits into the larger story of consuming, contributing to, and producing open source software.",
   "main": "script/server",
   "authors": [
@@ -7,7 +7,7 @@
     "Inc. <opensource@github.com>"
   ],
   "license": "CC-BY",
-  "homepage": "https://github.com/github/open-source-handbook",
+  "homepage": "https://github.com/github/open-source-guide",
   "dependencies": {
     "anchor-js": "^3.2.1"
   }

--- a/notices.md
+++ b/notices.md
@@ -14,7 +14,7 @@ Running an open source project, like any human endeavor, involves uncertainty an
 
 Content is released under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/), which gives you permission to use content for almost any purpose but does not grant you any trademark permissions, so long as you note the license and give credit, such as follows:
 
-> Content based on [github.com/github/open-source-handbook](https://github.com/github/open-source-handbook) used under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) license.
+> Content based on [github.com/github/open-source-guide](https://github.com/github/open-source-guide) used under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) license.
 
 Code, including source files and code samples if any in the content, is released under [CC0-1.0](https://creativecommons.org/publicdomain/zero/1.0/).
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "open-source-handbook",
+  "name": "open-source-guide",
   "private": true,
   "scripts": {
     "test": "script/test"

--- a/script/html-proofer
+++ b/script/html-proofer
@@ -4,7 +4,7 @@ require "bundler/setup"
 require "html-proofer"
 
 url_ignores = [
-  /github\.com\/github\/open-source-handbook/ # not yet public
+  /github\.com\/github\/open-source-guide/ # not yet public
 ]
 
 HTMLProofer::Runner.new(["_site"],

--- a/script/test
+++ b/script/test
@@ -4,5 +4,5 @@ set -e
 
 script/build --config _config.yml,test/_config.yml
 bundle exec rake
-script/html-proofer -url-ignore "/github\.com\/github\/open-source-handbook/"
+script/html-proofer -url-ignore "/github\.com\/github\/open-source-guide/"
 script/test-prose


### PR DESCRIPTION
This renames the repo from `open-source-handbook` to `open-source-guide` to match new name.

