### PR TITLE
Fix page title

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ We've put together the following guidelines to help you figure out where you can
 0. [Community](#community)
 
 ## Types of contributions we're looking for
-First and foremost, this project is a forum to discuss open source best practices, then document them in a guide when we've found consensus. Your first contribution might be starting a new conversation, or adding to an existing conversation, around best practices. You can do so under [Issues](https://github.com/github/open-source-guide/issues).
+First and foremost, this project is a forum to discuss open source best practices, then document them in a guide when we've found consensus. Your first contribution might be starting a new conversation, or adding to an existing conversation, around best practices. You can do so under [Issues](https://github.com/github/opensource.guide/issues).
 
 There are also many ways you can directly contribute to the guides (in descending order of need):
 
@@ -42,7 +42,7 @@ Before we get started, here are a few things we expect from you (and that you sh
 
 ## How to contribute
 
-If you'd like to contribute, start by searching through the [issues](https://github.com/github/open-source-guide/issues) and [pull requests](https://github.com/github/open-source-guide/pulls) to see whether someone else has raised a similar idea or question.
+If you'd like to contribute, start by searching through the [issues](https://github.com/github/opensource.guide/issues) and [pull requests](https://github.com/github/opensource.guide/pulls) to see whether someone else has raised a similar idea or question.
 
 If you don't see your idea listed, and you think it fits into the goals of this guide, do one of the following:
 * **If your contribution is minor,** such as a typo fix, **or self-contained,** such as writing a translation, open a pull request.
@@ -68,6 +68,6 @@ This repo is currently maintained by @nayafia and @bkeepers, who have commit acc
 
 ## Community
 
-Discussions about the Open Source Guides take place on this repository's [Issues](https://github.com/github/open-source-guide/issues) and [Pull Requests](https://github.com/github/open-source-guide/pulls) sections. Anybody is welcome to join these conversations. There is also a [mailing list](http://eepurl.com/cecpnT) for regular updates.
+Discussions about the Open Source Guides take place on this repository's [Issues](https://github.com/github/opensource.guide/issues) and [Pull Requests](https://github.com/github/opensource.guide/pulls) sections. Anybody is welcome to join these conversations. There is also a [mailing list](http://eepurl.com/cecpnT) for regular updates.
 
 Wherever possible, do not take these conversations to private channels, including contacting the maintainers directly. Keeping communication public means everybody can benefit and learn from the conversation.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Open Source Guides
 
-[![Build Status](https://travis-ci.org/github/open-source-guide.svg?branch=gh-pages)](https://travis-ci.org/github/open-source-guide)
+[![Build Status](https://travis-ci.org/github/opensource.guide.svg?branch=gh-pages)](https://travis-ci.org/github/opensource.guide)
 
 Open Source Guides (https://opensource.guide/) are a collection of resources for individuals, communities, and companies who want to learn how to run and contribute to an open source project.
 

--- a/_config.yml
+++ b/_config.yml
@@ -51,7 +51,7 @@ sass:
 branch: gh-pages
 
 github:
-  repository_nwo: github/open-source-guide
+  repository_nwo: github/opensource.guide
 
 twitter:
   username: github

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-title: "Open Source Guide"
+title: "Open Source Guides"
 description: "A community guide for open source creators."
 
 exclude:

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: "Open Source Guides"
-description: "A community guide for open source creators."
+description: "Learn how to launch and grow your project."
 
 exclude:
   - bin

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -51,7 +51,7 @@
       <a href="https://github.com">
         <svg height="20" class="octicon octicon-mark-github v-align-middle fill-gray mx-1" aria-label="GitHub" viewBox="0 0 16 16" version="1.1" width="20" role="img"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path></svg>
       </a>
-      and <a href="https://github.com/github/open-source-guide/graphs/contributors" class="text-gray">friends</a>
+      and <a href="https://github.com/github/opensource.guide/graphs/contributors" class="text-gray">friends</a>
     </div>
   </div>
 </footer>

--- a/_layouts/article-alt.html
+++ b/_layouts/article-alt.html
@@ -7,10 +7,10 @@ layout: default
     <div class="float-sm-right">
       <ul class="main-links d-flex flex-wrap flex-items-stretch border-left border-bottom border-sm-0 list-style-none">
         <li class="d-inline-block border-right">
-          <a class="d-block p-3 p-sm-4" href="https://github.com/github/open-source-guide#open-source-guides">About</a>
+          <a class="d-block p-3 p-sm-4" href="https://github.com/github/opensource.guide#readme">About</a>
         </li>
         <li class="d-inline-block border-right">
-          <a class="d-block p-3 p-sm-4" href="https://github.com/github/open-source-guide/blob/gh-pages/CONTRIBUTING.md">Contribute</a>
+          <a class="d-block p-3 p-sm-4" href="https://github.com/github/opensource.guide/blob/gh-pages/CONTRIBUTING.md">Contribute</a>
         </li>
       </ul>
     </div>

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -7,10 +7,10 @@ layout: default
     <div class="float-sm-right">
       <ul class="main-links d-flex flex-wrap flex-items-stretch border-left border-bottom border-sm-0 list-style-none">
         <li class="d-inline-block border-right">
-          <a class="d-block p-3 p-sm-4" href="https://github.com/github/open-source-guide#open-source-guides">About</a>
+          <a class="d-block p-3 p-sm-4" href="https://github.com/github/opensource.guide#readme">About</a>
         </li>
         <li class="d-inline-block border-right">
-          <a class="d-block p-3 p-sm-4" href="https://github.com/github/open-source-guide/blob/gh-pages/CONTRIBUTING.md">Contribute</a>
+          <a class="d-block p-3 p-sm-4" href="https://github.com/github/opensource.guide/blob/gh-pages/CONTRIBUTING.md">Contribute</a>
         </li>
       </ul>
     </div>

--- a/index.html
+++ b/index.html
@@ -7,10 +7,10 @@ layout: default
     <div class="float-sm-right">
       <ul class="main-links d-flex flex-wrap flex-items-stretch border-left border-bottom border-sm-0 list-style-none">
         <li class="d-inline-block border-right">
-          <a class="d-block p-3 p-sm-4" href="https://github.com/github/open-source-guide#open-source-guides">About</a>
+          <a class="d-block p-3 p-sm-4" href="https://github.com/github/opensource.guide#readme">About</a>
         </li>
         <li class="d-inline-block border-right">
-          <a class="d-block p-3 p-sm-4" href="https://github.com/github/open-source-guide/blob/gh-pages/CONTRIBUTING.md">Contribute</a>
+          <a class="d-block p-3 p-sm-4" href="https://github.com/github/opensource.guide/blob/gh-pages/CONTRIBUTING.md">Contribute</a>
         </li>
       </ul>
     </div>

--- a/notices.md
+++ b/notices.md
@@ -15,7 +15,7 @@ Running an open source project, like any human endeavor, involves uncertainty an
 
 Content is copyright © Open Source Guides authors, released under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/), which gives you permission to use content for almost any purpose (but does not grant you any trademark permissions), so long as you note the license and give credit, such as follows:
 
-> Content based on [github.com/github/open-source-guide](https://github.com/github/open-source-guide) used under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) license.
+> Content based on [github.com/github/opensource.guide](https://github.com/github/opensource.guide) used under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) license.
 
 Code, including source files and code samples if any in the content, is released under [CC0-1.0](https://creativecommons.org/publicdomain/zero/1.0/), with the following exceptions:
 

--- a/script/html-proofer
+++ b/script/html-proofer
@@ -4,7 +4,7 @@ require "bundler/setup"
 require "html-proofer"
 
 url_ignores = [
-  'https://github.com/github/opensource.guide',
+  %r{^https://github.com/github/opensource.guide},
   'https://karissa.github.io/post/okf-de',
   'https://this-week-in-rust.org/',
   'https://www.vagrantup.com/'

--- a/script/html-proofer
+++ b/script/html-proofer
@@ -4,6 +4,7 @@ require "bundler/setup"
 require "html-proofer"
 
 url_ignores = [
+  'https://github.com/github/opensource.guide',
   'https://karissa.github.io/post/okf-de',
   'https://this-week-in-rust.org/',
   'https://www.vagrantup.com/'


### PR DESCRIPTION
@theo-armour brought up in #355:

> Open Source Guide(s) - singular or plural?

Fair question. It should always be "Open Source Guides", because there are multiple of them, and they live at opensource.guide (we can't make the TLD plural).

- [x] Page title: "Open Source Guides"
- [x] Rename repository to github/opensource.guide

Thoughts?

Fixes #355