### PR TITLE
I18n: Keeping translations updated

### DIFF
--- a/docs/translations.md
+++ b/docs/translations.md
@@ -14,12 +14,14 @@ If there's not, then today is your day to lead this effort! Here's how to start:
 
 ## Keeping a translation updated
 
-Git is pretty good at making it easy to see what files have changed. We'll try to make it as easy as possible for you to keep your translation up to date. Here is the recommended process.
+Git is pretty good at making it easy to see what files have changed. We'll try to make it as easy as possible for you to keep your translation up to date.
 
-> These directions assume you have two [remotes](https://git-scm.com/docs/git-remote) configured for your local clone of this repository.
->
-> 1. `origin` - the translation fork. If you didn't originally clone this from the fork, you can update it with `git remote set-url origin https://github.com/[yourname]/open-source-guide.git`
-> 2. `upstream` - `git remote add upstream https://github.com/github/open-source-guide.git`
+These directions assume you have two [remotes](https://git-scm.com/docs/git-remote) configured for your local clone of is repository.
+
+0. `origin` - the translation fork. If you didn't originally clone this from the fork, you can update it with `git mote set-url origin https://github.com/[yourname]/open-source-guide.git`
+0. `upstream` - `git remote add upstream https://github.com/github/open-source-guide.git`
+
+Here is the recommended process:
 
 0. Run `$ script/sync-translation` to merge the latest changes from upstream and open a Pull Request on your fork.
 0. If files requiring translation have been modified, they will be added to a checklist in the Pull Request.

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -14,6 +14,13 @@ If there's not, then today is your day to lead this effort! Here's how to start:
 
 ## Keeping a translation updated
 
-TODO
+Git is pretty good at making it easy to see what files have changed. We'll try to make it as easy as possible for you to keep your translation up to date. Here is the recommended process.
 
-should be easy to merge in changes from upstream without conflicts
+> These directions assume you have two [remotes](https://git-scm.com/docs/git-remote) configured for your local clone of this repository.
+>
+> 1. `origin` - the translation fork. If you didn't originally clone this from the fork, you can update it with `git remote set-url origin https://github.com/[yourname]/open-source-guide.git`
+> 2. `upstream` - `git remote add upstream https://github.com/github/open-source-guide.git`
+
+0. Run `$ script/sync-translation` to merge the latest changes from upstream and open a Pull Request on your fork.
+0. If files requiring translation have been modified, they will be added to a checklist in the Pull Request.
+0. Once all files have been updated, merge the pull request.

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -14,15 +14,14 @@ If there's not, then today is your day to lead this effort! Here's how to start:
 
 ## Keeping a translation updated
 
-Git is pretty good at making it easy to see what files have changed. We'll try to make it as easy as possible for you to keep your translation up to date.
+Git is pretty good at tracking files that have changed. We'll try to make it as easy as possible for you to keep your translation up to date.
 
-These directions assume you have two [remotes](https://git-scm.com/docs/git-remote) configured for your local clone of is repository.
-
-0. `origin` - the translation fork. If you didn't originally clone this from the fork, you can update it with `git mote set-url origin https://github.com/[yourname]/open-source-guide.git`
-0. `upstream` - `git remote add upstream https://github.com/github/open-source-guide.git`
+Note: These directions assume the `origin` [remote](https://git-scm.com/docs/git-remote) is the translation fork. If you didn't originally clone the repository from the fork, you can update it with `git remote set-url origin https://github.com/[yourname]/opensource.guide.git`.
 
 Here is the recommended process:
 
 0. Run `$ script/sync-translation` to merge the latest changes from upstream and open a Pull Request on your fork.
 0. If files requiring translation have been modified, they will be added to a checklist in the Pull Request.
 0. Once all files have been updated, merge the pull request.
+
+Run this script as often as you want to keep your translation up to date.

--- a/script/sync-translation
+++ b/script/sync-translation
@@ -5,56 +5,57 @@
 #   Usage: script/sync-upstream [remote]
 #
 # TODO:
-# - [x] create branch and merge upstream changes
-# - [x] get diff of changes to notable files
-# - [ ] open PR with checkboxes for changes to translatable files
 # - [ ] handle merge conflicts with `git merge --continue`
-# - [ ] remove all the TODOs
 
 set -e
 
 # If there's not an upstream remote, set it.
 if ! git remote show | grep -q upstream; then
-  git remote add upstream https://github.com/github/open-source-guide.git
+  git remote add upstream https://github.com/github/opensource.guide.git
 fi
 
-git fetch upstream
-
 REMOTE=${1:-"origin"}
+BASE="$REMOTE/gh-pages"
+# TODO: remove once script is working
+BASE=42b97f47d15422a27a7ac7acd1e3153efc98dc46 # randomly selected old commit for testing
+HEAD="upstream/gh-pages"
 
-# BASE=$(git rev-parse $REMOTE/gh-pages)
-# TODO: replace v with ^
-BASE=0fc50236af4da7a5a339f9681f7c30634f415120 # randomly selected old commit for testing
-HEAD=$(git rev-parse upstream/i18n)
-BRANCH="sync-${HEAD:0:8}"
+git fetch upstream
+git fetch $REMOTE
+
+BASE_SHA=$(git rev-parse $BASE)
+HEAD_SHA=$(git rev-parse $HEAD)
+BRANCH="sync-${HEAD_SHA:0:8}"
 
 TRANSLATABLE_FILES="
-  _articles/en-US
+  _articles
   _data/locale/en-US.yml
 "
 
 ## Create a new branch and merge in the changes from upstream.
-# TODO: remove echos
-echo git checkout -b $BRANCH $BASE
-echo git merge --no-edit $HEAD
+echo "Creating branch $BRANCH based off $BASE"
+git checkout -B $BRANCH $BASE
+echo "Merging in latest changes from $HEAD"
+git merge -q --no-edit $HEAD
+git push $REMOTE $BRANCH
 
-CHANGED_FILES=$(git diff --name-only $BASE $HEAD -- $TRANSLATABLE_FILES)
+CHANGED_FILES=$(git diff --name-only $BASE_SHA $HEAD_SHA -- $TRANSLATABLE_FILES)
 
-TEMPLATE="This pull request syncs changes from upstream.
-
-[View changes](https://github.com/github/open-source-guide/compare/$BASE...$HEAD)
-
-Check the changes in each of these files and update the translation accordingly:
+TEMPLATE="Sync changes from upstream
+\n
+\n[View changes](https://github.com/github/opensource.guide/compare/$BASE_SHA...$HEAD_SHA)
 "
 
 if [ -z "$CHANGED_FILES" ]; then
-  TEMPLATE="$TEMPLATE\nNo translatable files were changed upstream."
+  TEMPLATE="$TEMPLATE\nNo files that need translation were changed upstream."
+else
+  TEMPLATE="$TEMPLATE\nCheck the changes in each of these files and update the translation accordingly:\n"
+
+  for file in $CHANGED_FILES; do
+    TEMPLATE="$TEMPLATE\n- [ ] \`$file\`"
+  done
 fi
 
-for file in $CHANGED_FILES; do
-  TEMPLATE="$TEMPLATE\n- [ ] $file"
-done
+OWNER=$(git config --get remote.$REMOTE.url | sed -Ene 's#.*github.com[/:]([^/]*)/.*#\1#p')
 
-# TODO: remove echos
-echo "$TEMPLATE"
-echo $TEMPLATE | echo hub pull-request -o -F - -h $BRANCH -b gh-pages
+echo $TEMPLATE | hub pull-request -o -F - -b $OWNER:gh-pages -h $OWNER:$BRANCH

--- a/script/sync-translation
+++ b/script/sync-translation
@@ -41,10 +41,7 @@ git push $REMOTE $BRANCH
 
 CHANGED_FILES=$(git diff --name-only $BASE_SHA $HEAD_SHA -- $TRANSLATABLE_FILES)
 
-TEMPLATE="Sync changes from upstream
-\n
-\n[View changes](https://github.com/github/opensource.guide/compare/$BASE_SHA...$HEAD_SHA)
-"
+TEMPLATE="Sync changes from upstream\n\n"
 
 if [ -z "$CHANGED_FILES" ]; then
   TEMPLATE="$TEMPLATE\nNo files that need translation were changed upstream."

--- a/script/sync-translation
+++ b/script/sync-translation
@@ -1,0 +1,8 @@
+#!/bin/sh
+#
+# Sync changes from up stream
+#
+# TODO:
+# - create branch and merge upstream changes
+# - get diff of changes to notable files
+# - open PR with checkboxes for changes to translatable files

--- a/script/sync-translation
+++ b/script/sync-translation
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Sync changes from up stream
+# Sync changes from upstream and open a pull request
 #
 #   Usage: script/sync-upstream [remote]
 #
@@ -9,6 +9,8 @@
 
 set -e
 
+which -s hub || (echo "This script requires the 'hub' command: http://hub.github.com/" && exit 1)
+
 # If there's not an upstream remote, set it.
 if ! git remote show | grep -q upstream; then
   git remote add upstream https://github.com/github/opensource.guide.git
@@ -16,9 +18,9 @@ fi
 
 REMOTE=${1:-"origin"}
 BASE="$REMOTE/gh-pages"
-# TODO: remove once script is working
-BASE=42b97f47d15422a27a7ac7acd1e3153efc98dc46 # randomly selected old commit for testing
-HEAD="upstream/gh-pages"
+# FIXME: switch to upstream/gh-pages before this is merged:
+# https://github.com/github/open-source-guide/pull/295
+HEAD="upstream/i18n"
 
 git fetch upstream
 git fetch $REMOTE

--- a/script/sync-translation
+++ b/script/sync-translation
@@ -32,6 +32,7 @@ BRANCH="sync-${HEAD_SHA:0:8}"
 TRANSLATABLE_FILES="
   _articles
   _data/locale/en-US.yml
+  _config
 "
 
 ## Create a new branch and merge in the changes from upstream.

--- a/script/sync-translation
+++ b/script/sync-translation
@@ -2,7 +2,59 @@
 #
 # Sync changes from up stream
 #
+#   Usage: script/sync-upstream [remote]
+#
 # TODO:
-# - create branch and merge upstream changes
-# - get diff of changes to notable files
-# - open PR with checkboxes for changes to translatable files
+# - [x] create branch and merge upstream changes
+# - [x] get diff of changes to notable files
+# - [ ] open PR with checkboxes for changes to translatable files
+# - [ ] handle merge conflicts with `git merge --continue`
+# - [ ] remove all the TODOs
+
+set -e
+
+# If there's not an upstream remote, set it.
+if ! git remote show | grep -q upstream; then
+  git remote add upstream https://github.com/github/open-source-guide.git
+fi
+
+git fetch upstream
+
+REMOTE=${1:-"origin"}
+
+# BASE=$(git rev-parse $REMOTE/gh-pages)
+# TODO: replace v with ^
+BASE=0fc50236af4da7a5a339f9681f7c30634f415120 # randomly selected old commit for testing
+HEAD=$(git rev-parse upstream/i18n)
+BRANCH="sync-${HEAD:0:8}"
+
+TRANSLATABLE_FILES="
+  _articles/en-US
+  _data/locale/en-US.yml
+"
+
+## Create a new branch and merge in the changes from upstream.
+# TODO: remove echos
+echo git co -b $BRANCH $BASE
+echo git merge --no-edit $HEAD
+
+CHANGED_FILES=$(git diff --name-only $BASE $HEAD -- $TRANSLATABLE_FILES)
+
+TEMPLATE="This pull request syncs changes from upstream.
+
+[View changes](https://github.com/github/open-source-guide/compare/$BASE...$HEAD)
+
+Check the changes in each of these files and update the translation accordingly:
+"
+
+if [ -z "$CHANGED_FILES" ]; then
+  TEMPLATE="$TEMPLATE\nNo translatable files were changed upstream."
+fi
+
+for file in $CHANGED_FILES; do
+  TEMPLATE="$TEMPLATE\n- [ ] $file"
+done
+
+# TODO: remove echos
+echo "$TEMPLATE"
+echo $TEMPLATE | echo hub pull-request -o -F - -h $BRANCH -b gh-pages

--- a/script/sync-translation
+++ b/script/sync-translation
@@ -35,7 +35,7 @@ TRANSLATABLE_FILES="
 
 ## Create a new branch and merge in the changes from upstream.
 # TODO: remove echos
-echo git co -b $BRANCH $BASE
+echo git checkout -b $BRANCH $BASE
 echo git merge --no-edit $HEAD
 
 CHANGED_FILES=$(git diff --name-only $BASE $HEAD -- $TRANSLATABLE_FILES)


### PR DESCRIPTION
@webknjaz [commented in #288](https://github.com/github/open-source-guide/issues/288#issuecomment-283927635):

> there's additional concern, which bothers me for a while: fixes or improvements to original articles go to this repo and there's no way to automatically confirm that translated version still corresponds original one.

I met with @alebourne and @zeke last week to talk more about how they plan to handle localization for several other GitHub projects. Long term, the plan is to adopt a translation management tool similar to what was [discussed in #295](https://github.com/github/open-source-guide/pull/295#issuecomment-281414390), which keeps track of which files need updated as content changes. They are well into the process of evaluating options and I'm following their progress closely.

Near term, I'd like to make it as easy as possible for to keep translations up to date, and I think git can help us here. Here's what I propose:

1. Each translation maintainer will occasionally run `$ script/sync-translation` to merge the latest changes from upstream and open a Pull Request on their fork.
2. If files requiring translation have been modified, they will be added to a checklist in the Pull Request with links to the diff.
3. Once all files have been updated, merge the pull request.

This will require the translation authors to manually scan the diffs and make the updates, but it at least provides a lightweight process for doing it so all translations are managed the same.

I would love to hear feedback on this approach. 

cc @nandomoreirame @lijiangsheng1 #295 