### PR TITLE
Remove "Section x" headings

### DIFF
--- a/assets/css/custom.scss
+++ b/assets/css/custom.scss
@@ -136,35 +136,12 @@ blockquote {
     text-align: center;
     margin-bottom: $spacer-3;
     line-height: 1.25;
+    margin-top: $spacer-6;
 
-    &:before {
-      display: block;
-      font-size: 17px;
-      font-weight: 700;
-      margin-bottom: $spacer-4;
-      margin-top: 40px;
-
-      @include breakpoint(md) {
-        margin-top: 120px;
-      }
-
-    }
-  }
-
-  h2:nth-of-type(1):before {
-    content: "Section 1";
     @include breakpoint(md) {
-      margin-top: 60px;
+      margin-top: $spacer-6 * 2;
     }
   }
-  h2:nth-of-type(2):before { content: "Section 2"; }
-  h2:nth-of-type(3):before { content: "Section 3"; }
-  h2:nth-of-type(4):before { content: "Section 4"; }
-  h2:nth-of-type(5):before { content: "Section 5"; }
-  h2:nth-of-type(6):before { content: "Section 6"; }
-  h2:nth-of-type(7):before { content: "Section 7"; }
-  h2:nth-of-type(8):before { content: "Section 8"; }
-  h2:nth-of-type(9):before { content: "Section 9"; }
 
   h2 + p {
     text-align: center;


### PR DESCRIPTION
The "Section x" headings are currently implemented in CSS, which is not very friendly to i18n support (#295). There are a few workarounds (like moving the labels into the content, or adding selectors for each language like `html[lang=en] h2:before`), but I'm not sure the added complexity is worth it.

What do you think about removing them entirely?

@sophshep

## Before 
<img width="813" alt="building_welcoming_communities_-_open_source_guides" src="https://cloud.githubusercontent.com/assets/173/23735757/3a1bc2f8-044d-11e7-9eaf-d6a013a1c9a6.png">

## After
<img width="812" alt="building_welcoming_communities_-_open_source_guides" src="https://cloud.githubusercontent.com/assets/173/23735760/3ef02490-044d-11e7-92b2-d6c1bd644053.png">
