### PR TITLE
Remove link returning a 401

### DIFF
--- a/_articles/starting-a-project.md
+++ b/_articles/starting-a-project.md
@@ -232,7 +232,7 @@ Consider clarity above all. Puns are fun, but remember that some jokes might not
 
 ### Avoiding name conflicts
 
-[Check for open source projects with a similar name](http://ivantomic.com/projects/ospnc/), especially if you share the same language or ecosystem. If your name overlaps with a popular existing project, you might confuse your audience.
+Check for open source projects with a similar name, especially if you share the same language or ecosystem. If your name overlaps with a popular existing project, you might confuse your audience.
 
 If you want a website, Twitter handle, or other properties to represent your project, make sure you can get the names you want. Ideally, [reserve those names now](https://instantdomainsearch.com/) for peace of mind, even if you don't intend to use them just yet.
 


### PR DESCRIPTION
The link to a resource for checking for project name conflicts is broken, which is a shame. We'll just have to do without it.

Closes #374.