### PR TITLE
Change <label> "for" attribute to match the right checkbox

### DIFF
--- a/_articles/how-to-contribute.md
+++ b/_articles/how-to-contribute.md
@@ -301,7 +301,7 @@ Now do the same for the project's pull requests.
 
 <div class="clearfix mb-2">
   <input type="checkbox" id="cbox10" class="d-block float-left mt-1 mr-2" value="checkbox">
-  <label for="cbox8" class="overflow-hidden d-block text-normal">
+  <label for="cbox10" class="overflow-hidden d-block text-normal">
     How many open pull requests are there?
   </label>
 </div>


### PR DESCRIPTION
In chapter: how-to-contribute, there is a little checkbox label not matching.😇

### Before
![2017-04-19 5 53 27](https://cloud.githubusercontent.com/assets/4152178/25174217/3d5a02f2-2529-11e7-9f48-3f5620ace862.png)
### After 
![2017-04-19 5 53 12](https://cloud.githubusercontent.com/assets/4152178/25174458/01e421c0-252a-11e7-8096-ad203f536516.png)

