### PR TITLE
Add probot-stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -9,7 +9,7 @@ exemptLabels:
   - pinned
   - security
 # Label to use when marking as stale
-staleLabel: wontfix
+staleLabel: stale
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,21 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale Issue or Pull Request is closed
+daysUntilClose: 7
+# Issues or Pull Requests with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+# Label to use when marking as stale
+staleLabel: wontfix
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale Issue or Pull Request. Set to `false` to disable
+closeComment: false
+# Limit to only `issues` or `pulls`
+# only: issues


### PR DESCRIPTION
probot-stale automatically marks issues and PRs that sit open for long periods with no activity as stale, comments telling people and then closes them if there's no more activity. This saves a human having to manually curate this repository on a regular basis as things that aren't getting done will get closed.

Anyone (particularly @github/open-source-team and @github/open-source) please chime in here for thoughts on this and the specific values it's using.