### PR TITLE
footer: add MailChimp group.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -22,11 +22,12 @@
           <form action="//github.us11.list-manage.com/subscribe/post?u=9d7ced8c4bbd6c2f238673f0f&amp;id=b514344ba3" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
               <div id="mc_embed_signup_scroll">
                 <img src="{{ "/assets/images/illos/bird.svg" | relative_url }}" class="little-illo mb-3" alt="bird illustration">
-              <h3 class="alt-h3 mb-3">Subscribe to updates</h3>
+              <h3 class="alt-h3 mb-3">Subscribe to GitHub Open Source updates</h3>
 
               <div class="mc-field-group col-12">
                   <label for="mce-EMAIL" class="d-none">Email Address</label>
                   <input type="email" placeholder="Email Address" name="EMAIL" class="form-input required email d-block col-10 mx-auto py-2 px-3 mb-3" id="mce-EMAIL" autocomplete="home email">
+                  <input type="checkbox" value="1" name="group[9617][1]" id="mce-group[9617]-9617-0" checked="checked" style="display:none">
                   <input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="btn btn-outline">
               </div>
               <div id="mce-responses" class="clear">


### PR DESCRIPTION
This helps us ensure that the emails to this list are targeted and appropriate.