### PR TITLE
Add "back to all guides" link.

### DIFF
--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -51,6 +51,9 @@ layout: default
   <div class="article-body mx-auto px-3 pt-4 pt-lg-6 pb-6 col-md-10 col-lg-8 col-xl-6">
     {{ content }}
   </div>
+  <div class="text-center pb-4">
+    <a class="alt-h3" href="/">Back to all guides</a>
+  </div>
 </article>
 
 {% include footer.html %}


### PR DESCRIPTION
This is in the footer of all guides to people can jump quickly back to read more guides.

First part of https://github.com/github/opensource.guide/issues/427.