### PR TITLE
Add related guides to page footer.

### DIFF
--- a/_articles/best-practices.md
+++ b/_articles/best-practices.md
@@ -12,8 +12,8 @@ toc:
 order: 5
 image: /assets/images/cards/best-practices.png
 related:
-  - building
-  - coc
+  - metrics
+  - leadership
 ---
 
 ## What does it mean to be a maintainer?

--- a/_articles/best-practices.md
+++ b/_articles/best-practices.md
@@ -11,6 +11,9 @@ toc:
   its-okay-to-hit-pause: "It’s okay to hit pause"
 order: 5
 image: /assets/images/cards/best-practices.png
+related:
+  - building
+  - coc
 ---
 
 ## What does it mean to be a maintainer?

--- a/_articles/building-community.md
+++ b/_articles/building-community.md
@@ -8,6 +8,9 @@ toc:
   resolving-conflicts: "Resolving conflicts"
 order: 4
 image: /assets/images/cards/building.png
+related:
+  - best-practices
+  - coc
 ---
 
 ## Setting your project up for success

--- a/_articles/code-of-conduct.md
+++ b/_articles/code-of-conduct.md
@@ -9,6 +9,9 @@ toc:
   enforcing-your-code-of-conduct: "Enforcing your code of conduct"
 order: 8
 image: /assets/images/cards/coc.png
+related:
+  - building
+  - leadership
 ---
 
 ## Why do I need a code of conduct?

--- a/_articles/finding-users.md
+++ b/_articles/finding-users.md
@@ -11,6 +11,9 @@ toc:
   build-a-reputation: "Build a reputation"
 order: 3
 image: /assets/images/cards/finding.png
+related:
+  - beginners
+  - building
 ---
 
 ## Spreading the word

--- a/_articles/getting-paid.md
+++ b/_articles/getting-paid.md
@@ -9,6 +9,9 @@ toc:
   building-a-case-for-financial-support: "Building a case for financial support"
 order: 7
 image: /assets/images/cards/getting-paid.png
+related:
+  - best-practices
+  - leadership
 ---
 
 ## Why some people seek financial support

--- a/_articles/how-to-contribute.md
+++ b/_articles/how-to-contribute.md
@@ -11,6 +11,9 @@ toc:
   what-happens-after-you-submit-a-contribution: "What happens after you submit a contribution"
 order: 1
 image: /assets/images/cards/contribute.png
+related:
+  - beginners
+  - building
 ---
 
 ## Why contribute to open source?

--- a/_articles/leadership-and-governance.md
+++ b/_articles/leadership-and-governance.md
@@ -12,6 +12,9 @@ toc:
   do-i-need-a-legal-entity-to-support-my-project: "Do I need a legal entity to support my project?"
 order: 6
 image: /assets/images/cards/leadership.png
+related:
+  - best-practices
+  - metrics
 ---
 
 ## Understanding governance for your growing project

--- a/_articles/legal.md
+++ b/_articles/legal.md
@@ -12,6 +12,9 @@ toc:
   what-does-my-companys-legal-team-need-to-know: "What does my company’s legal team need to know?"
 order: 10
 image: /assets/images/cards/legal.png
+related:
+  - contribute
+  - leadership
 ---
 
 ## Understanding the legal implications of open source

--- a/_articles/metrics.md
+++ b/_articles/metrics.md
@@ -10,6 +10,9 @@ toc:
   maintainer-activity: "Maintainer activity"
 order: 9
 image: /assets/images/cards/metrics.png
+related:
+  - finding
+  - best-practices
 ---
 
 ## Why measure anything?

--- a/_articles/starting-a-project.md
+++ b/_articles/starting-a-project.md
@@ -10,6 +10,9 @@ toc:
   your-pre-launch-checklist: "Your pre-launch checklist"
 order: 2
 image: /assets/images/cards/beginner.png
+related:
+  - finding
+  - building
 ---
 
 ## The "what" and "why" of open source

--- a/_data/fields.yml
+++ b/_data/fields.yml
@@ -23,3 +23,6 @@ order:
   type: Integer
 
 image: {}
+
+related:
+  type: Array

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -56,4 +56,33 @@ layout: default
   </div>
 </article>
 
+{% if page.related %}
+<div class="container-lg p-responsive mx-auto border-top text-center pt-5">
+  <h2 class="alt-h2">Related Guides</h2>
+  <div class="gutter-sm d-flex flex-wrap flex-items-stretch pb-md-6">
+  {% for related in page.related %}
+    {% assign article = site.articles | where: "class", related | first %}
+    <div class="col-12 col-sm-9 mx-auto col-md-6 mt-4 mt-lg-5">
+      <a href="{{ article.url | relative_url }}" class="guide-cover {{ article.class }} card height-full d-block">
+
+        <div class="lh-none guide-cover-img text-center pt-4">
+          <img src="{{ site.baseurl }}/assets/images/illos/{{ article.class }}.svg" class="" alt="{{ article.title }} illustration">
+        </div>
+
+        <div class="flex-self-end p-4 text-center p-lg-5">
+          <h3 class="alt-h3 text-bold lh-condensed mb-2 text-black">
+            {{ article.title }}
+          </h3>
+          <div class="mb-0 text-gray">
+            {{ article.description | markdownify }}
+          </div>
+        </div>
+
+      </a>
+    </div>
+  {% endfor %}
+  </div>
+</div>
+{% endif %}
+
 {% include footer.html %}


### PR DESCRIPTION
Allow specifying `related` in article metadata and using that to add related guides to the bottom of an article.

Added an example to Best Practices which are bad and wrong and should be updated by @nayafia.

Currently looks like:
<img width="1153" alt="screen shot 2017-08-01 at 18 03 34" src="https://user-images.githubusercontent.com/125011/28837179-c34795d0-76e3-11e7-86e8-6e11190a3d77.png">

Fixes #427.