### PR TITLE
Add es-AR to the official translations

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,9 @@ translations:
   en-US:
     name: English (US)
     url: https://opensource.guide
+  es-AR:
+    name: Español (AR)
+    url: https://es-ar.opensource.guide
 
 exclude:
   - bin


### PR DESCRIPTION
@consugus thanks for your work in leading up and completing the `en-AR` translation! It will be the first translation that we'll make "official", so there might be a bumps as we create and refine the process.

I've pushed your fork to https://github.com/opensourceguide/es-AR and sent you an invite to the organization.

- [ ] Get DNS set up (waiting for changes from team that manages DNS at GitHub)
- [ ] Merge https://github.com/opensourceguide/es-AR/pull/1 and ensure https://es-ar.opensource.guide is working
- [ ] Run `script/sync-translation` on fork to ensure it has all the latest changes (https://github.com/opensourceguide/es-AR/pull/2)
- [ ] Merge this PR

Closes #383 