### PR TITLE
Revert "Better link instructions for CODE_OF_CONDUCT #399"

### DIFF
--- a/_articles/en-US/code-of-conduct.md
+++ b/_articles/en-US/code-of-conduct.md
@@ -38,7 +38,7 @@ Wherever you can, use prior art. The [Contributor Covenant](http://contributor-c
 
 The [Django Code of Conduct](https://www.djangoproject.com/conduct/) and the [Citizen Code of Conduct](http://citizencodeofconduct.org/) are also two good code of conduct examples.
 
-Place a CODE_OF_CONDUCT file in your project's root directory, and make it visible to your community by linking it from your CONTRIBUTING or README file.
+Place a CODE_OF_CONDUCT file in your project's root directory, and link to it from your README, so it's visible to your community.
 
 ## Deciding how you'll enforce your code of conduct
 


### PR DESCRIPTION
Reverts github/opensource.guide#411