### PR TITLE
Add OSS Finder into the resource list

### DIFF
--- a/_articles/en-US/how-to-contribute.md
+++ b/_articles/en-US/how-to-contribute.md
@@ -224,6 +224,7 @@ You can also use one of the following resources to help you discover and contrib
 * [24 Pull Requests](https://24pullrequests.com/)
 * [Up For Grabs](http://up-for-grabs.net/)
 * [Contributor-ninja](https://contributor.ninja)
+* [OSS Finder](https://ossfinder.netlify.com/)
 
 ### A checklist before you contribute
 


### PR DESCRIPTION
I've made an [open source](https://ossfinder.netlify.com/) to find open source softwares to contribute to.
I made a PR because I thought it'd be nice to be listed in the resource list as well.

Thank you.

- [x] Have you followed the [contributing guidelines](https://github.com/github/opensource.guide/blob/gh-pages/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value to the Guides?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

-----
