### PR TITLE
Fix broken link to automated tests

### DIFF
--- a/_articles/en-US/best-practices.md
+++ b/_articles/en-US/best-practices.md
@@ -35,7 +35,7 @@ Writing things down makes it easier to say no when something doesn't fit into yo
 
 Even if you don't use full paragraphs, jotting down bullet points is better than not writing at all.
 
-Remember to keep your documentation up-to-date. If you’re not able to always do this, delete your outdated documentation or indicate it is outdated so contributors know updates are welcome.
+Remember to keep your documentation up-to-date. If you're not able to always do this, delete your outdated documentation or indicate it is outdated so contributors know updates are welcome.
 
 ### Write down your project's vision
 

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -6,7 +6,7 @@ From the GitHub Manual of Style, which this style guide inherits from:
 >
 > In other words, the way we write is just as important as the way we design. Consider these things when writing copy.
 
-Where possible, [automated tests](../script/test-prose) enforce style rules.
+Where possible, [automated tests](../test/prose) enforce style rules.
 
 ## Content Principles
 All written content should follow these principles:


### PR DESCRIPTION
Looks like these were moved from `script/test-prose` to [test/prose](https://github.com/github/opensource.guide/blob/gh-pages/test/prose) in 874a0496fdce252985dddffa2bf1b30e5640f46c (see [diff](https://github.com/github/opensource.guide/commit/874a0496fdce252985dddffa2bf1b30e5640f46c#diff-0e2bc0f03fe54e5e0fff129205e6ee92L8)).

- [x] Have you followed the [contributing guidelines](https://github.com/github/opensource.guide/blob/gh-pages/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value to the Guides?
