### PR TITLE
Broken link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -9,7 +9,7 @@
           <h3 class="alt-h3 mb-3">{{ t.footer.contribute.heading }}</h3>
           <p class="mb-3 p-large">{{ t.footer.contribute.description }}</p>
           <p>
-            <a data-proofer-ignore href="https://github.com/{{ site.github.repository_nwo }}/edit/{{ site.branch }}/{{ page.path }}" class="btn btn-outline">
+            <a data-proofer-ignore href="https://github.com/{{ site.github.repository_nwo }}/edit/master/{{ page.path }}" class="btn btn-outline">
               {{ t.footer.contribute.button }}
             </a>
           </p>


### PR DESCRIPTION
The {{ site.branch }} returns an empty string which generates a broken link.
I replaced it directly with "master" like it's generated in the in [nav.html](https://github.com/github/opensource.guide/blob/503dbe10704482b0529bc3cf568f81e3206910c0/_includes/nav.html#L12).
