### PR TITLE
travis.yml: don't build all branches.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,6 @@ cache:
   directories:
     - node_modules
     - test/node_modules
-# Tell Travis to build gh-pages branch
-# https://docs.travis-ci.com/user/customizing-the-build#Safelisting-or-blocklisting-branches
 branches:
   only:
-    - gh-pages
-    - /.*/
+    - master


### PR DESCRIPTION
This avoids duplicate jobs on non-fork PRs.