### PR TITLE
Remove link to Contributor-ninja

### DIFF
--- a/_articles/how-to-contribute.md
+++ b/_articles/how-to-contribute.md
@@ -223,7 +223,6 @@ You can also use one of the following resources to help you discover and contrib
 * [CodeTriage](https://www.codetriage.com/)
 * [24 Pull Requests](https://24pullrequests.com/)
 * [Up For Grabs](http://up-for-grabs.net/)
-* [Contributor-ninja](https://contributor.ninja)
 
 ### A checklist before you contribute
 


### PR DESCRIPTION
removed link because https://contributor.ninja/ is no longer working.

- [x] Have you followed the [contributing guidelines](https://github.com/github/opensource.guide/blob/master/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value to the Guides?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

-----
