### PR TITLE
Revert "Bump primer-marketing from 6.2.1 to 6.2.2"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,49 +72,77 @@
       }
     },
     "primer-marketing": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/primer-marketing/-/primer-marketing-6.2.2.tgz",
-      "integrity": "sha1-HXCHr91RD+JlcKGz182YGmUK63Y=",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/primer-marketing/-/primer-marketing-6.2.1.tgz",
+      "integrity": "sha1-+glktpILB48wKbn7HFrqqbnn78w=",
       "requires": {
-        "primer-marketing-buttons": "1.0.6",
-        "primer-marketing-support": "1.5.2",
-        "primer-marketing-type": "1.4.7",
-        "primer-marketing-utilities": "1.6.3",
-        "primer-page-headers": "1.4.7",
-        "primer-page-sections": "1.4.7",
-        "primer-support": "4.5.4",
-        "primer-tables": "1.4.7"
+        "primer-marketing-buttons": "1.0.5",
+        "primer-marketing-support": "1.5.1",
+        "primer-marketing-type": "1.4.6",
+        "primer-marketing-utilities": "1.6.2",
+        "primer-page-headers": "1.4.6",
+        "primer-page-sections": "1.4.6",
+        "primer-support": "4.5.3",
+        "primer-tables": "1.4.6"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.5.3",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.5.3.tgz",
+          "integrity": "sha1-2lHYjRZbRuYJWR06MCXlN1kq/Ns="
+        }
       }
     },
     "primer-marketing-buttons": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/primer-marketing-buttons/-/primer-marketing-buttons-1.0.6.tgz",
-      "integrity": "sha1-UMBSi4QtTnPGiEJR37vdnw4K4KI=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/primer-marketing-buttons/-/primer-marketing-buttons-1.0.5.tgz",
+      "integrity": "sha1-vBgM5+9l9fIHsB5lwU8iNMD74cQ=",
       "requires": {
-        "primer-support": "4.5.4"
+        "primer-support": "4.5.3"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.5.3",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.5.3.tgz",
+          "integrity": "sha1-2lHYjRZbRuYJWR06MCXlN1kq/Ns="
+        }
       }
     },
     "primer-marketing-support": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/primer-marketing-support/-/primer-marketing-support-1.5.2.tgz",
-      "integrity": "sha1-WfYpnvGtldv12xo6vEQfKdAfCYw="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/primer-marketing-support/-/primer-marketing-support-1.5.1.tgz",
+      "integrity": "sha1-s3tPMmzseMWaFkijwljH04E11Dc="
     },
     "primer-marketing-type": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/primer-marketing-type/-/primer-marketing-type-1.4.7.tgz",
-      "integrity": "sha1-NnXtxpoPMSBaE4cUSPt0jN5tEBY=",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/primer-marketing-type/-/primer-marketing-type-1.4.6.tgz",
+      "integrity": "sha1-m7nGPU/D1pk/MpsKlOaLD02Ykug=",
       "requires": {
-        "primer-marketing-support": "1.5.2",
-        "primer-support": "4.5.4"
+        "primer-marketing-support": "1.5.1",
+        "primer-support": "4.5.3"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.5.3",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.5.3.tgz",
+          "integrity": "sha1-2lHYjRZbRuYJWR06MCXlN1kq/Ns="
+        }
       }
     },
     "primer-marketing-utilities": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/primer-marketing-utilities/-/primer-marketing-utilities-1.6.3.tgz",
-      "integrity": "sha1-feBG/AX2Wt+NtYb/Fb56uHMsmOQ=",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/primer-marketing-utilities/-/primer-marketing-utilities-1.6.2.tgz",
+      "integrity": "sha1-mQUnpWG1oq+ryfr/aYztxuA0toA=",
       "requires": {
-        "primer-marketing-support": "1.5.2",
-        "primer-support": "4.5.4"
+        "primer-marketing-support": "1.5.1",
+        "primer-support": "4.5.3"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.5.3",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.5.3.tgz",
+          "integrity": "sha1-2lHYjRZbRuYJWR06MCXlN1kq/Ns="
+        }
       }
     },
     "primer-navigation": {
@@ -126,21 +154,35 @@
       }
     },
     "primer-page-headers": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/primer-page-headers/-/primer-page-headers-1.4.7.tgz",
-      "integrity": "sha1-nZgMhoDI+Kt/+DjMMHDaTmJSaPw=",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/primer-page-headers/-/primer-page-headers-1.4.6.tgz",
+      "integrity": "sha1-IZsowsFdN/F7cXVaTG464o6JtAA=",
       "requires": {
-        "primer-marketing-support": "1.5.2",
-        "primer-support": "4.5.4"
+        "primer-marketing-support": "1.5.1",
+        "primer-support": "4.5.3"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.5.3",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.5.3.tgz",
+          "integrity": "sha1-2lHYjRZbRuYJWR06MCXlN1kq/Ns="
+        }
       }
     },
     "primer-page-sections": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/primer-page-sections/-/primer-page-sections-1.4.7.tgz",
-      "integrity": "sha1-5YnZWzKie052Yr3WAP298JXSY2k=",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/primer-page-sections/-/primer-page-sections-1.4.6.tgz",
+      "integrity": "sha1-8+OXfmarsbdi1c2s9b6KifX0rOs=",
       "requires": {
-        "primer-marketing-support": "1.5.2",
-        "primer-support": "4.5.4"
+        "primer-marketing-support": "1.5.1",
+        "primer-support": "4.5.3"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.5.3",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.5.3.tgz",
+          "integrity": "sha1-2lHYjRZbRuYJWR06MCXlN1kq/Ns="
+        }
       }
     },
     "primer-pagination": {
@@ -165,12 +207,19 @@
       }
     },
     "primer-tables": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/primer-tables/-/primer-tables-1.4.7.tgz",
-      "integrity": "sha1-4Z5PCt/uieu3bfudoH5Wx21xhAg=",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/primer-tables/-/primer-tables-1.4.6.tgz",
+      "integrity": "sha1-dNaBVnFxNocLa+m8jT6ogbVcLxY=",
       "requires": {
-        "primer-marketing-support": "1.5.2",
-        "primer-support": "4.5.4"
+        "primer-marketing-support": "1.5.1",
+        "primer-support": "4.5.3"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.5.3",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.5.3.tgz",
+          "integrity": "sha1-2lHYjRZbRuYJWR06MCXlN1kq/Ns="
+        }
       }
     },
     "primer-tooltips": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
   },
   "dependencies": {
     "primer-core": "6.10.0",
-    "primer-marketing": "6.2.2"
+    "primer-marketing": "6.2.1"
   }
 }


### PR DESCRIPTION
Reverts github/opensource.guide#641