### PR TITLE
Fix form input for users with dark OS theme

### DIFF
--- a/assets/css/custom.scss
+++ b/assets/css/custom.scss
@@ -176,7 +176,7 @@ blockquote {
     @include breakpoint(lg) { font-size: 26px; }
 
     &::after {
-      content:" ";
+      content: " ";
       display: block;
       margin: 1.5em auto;
       height: 5px;
@@ -203,7 +203,7 @@ blockquote {
 }
 
 .border-sm-0 {
-  @include breakpoint(sm) { border-bottom: none !important;}
+  @include breakpoint(sm) { border-bottom: none !important; }
 }
 
 .col-border {
@@ -211,7 +211,7 @@ blockquote {
 }
 
 .bg-gray-light {
-  background-color: #F3F3F3 !important;;
+  background-color: #F3F3F3 !important;
 }
 
 .text-black {
@@ -225,6 +225,8 @@ blockquote {
 .mc-field-group {
   .form-input {
     border: $border;
+    color: $text-gray-dark;
+    background-color: $bg-white;
     height: 40px;
   }
 }


### PR DESCRIPTION
- [x] Have you followed the [contributing guidelines](https://github.com/github/opensource.guide/blob/master/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value to the Guides?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

-----

Hey there!

First of all: thanks for this great project!

I noticed the e-mail input does not look great for users with a dark OS theme enabled (I'm one of these). This seems to be a very common issue in web design, as many users of macOS and Windows are not even aware there's a possibility of changing the appearance of OS native widgets; at least on most Linux distributions this is possible (GTK Themes). I even [ranted on Twitter](https://twitter.com/linusgroh/status/979349672602095617) about this once, sadly no great impact...

Long story short: one should NOT expect that the background color of an input will be `#ffffff` or similar! On the other hand, changing the color property to something dark-ish makes it even worse, as it completely makes the input unusable (dark text on dark background).

This PR provides a fix of the color and background color to fit with the overall design.

*I also changed some very very minor things on the fly, I know some maintainers can be picky about this... if so, please feel free to tell me and I'll create a new PR.*