### PR TITLE
Revert "Add missing ToC entry in code-of-conduct"

### DIFF
--- a/_articles/code-of-conduct.md
+++ b/_articles/code-of-conduct.md
@@ -8,7 +8,6 @@ toc:
   establishing-a-code-of-conduct: "Establishing a code of conduct"
   deciding-how-youll-enforce-your-code-of-conduct: "Deciding how you’ll enforce your code of conduct"
   enforcing-your-code-of-conduct: "Enforcing your code of conduct"
-  your-responsibilities-as-a-maintainer: "Your responsibilities as a maintainer"
 order: 8
 image: /assets/images/cards/coc.png
 related:

--- a/_articles/es/code-of-conduct.md
+++ b/_articles/es/code-of-conduct.md
@@ -8,7 +8,6 @@ toc:
   estableciendo-un-c&oacute;digo-de-conducta: "Estableciendo un c&oacute;digo de conducta"
   decidiendo-de-qu&eacute;-manera-vas-a-aplicar-tu-c&oacute;digo-de-conducta: "Decidiendo de qu&eacute; manera vas a aplicar tu c&oacute;digo de conducta"
   aplicando-tu-c&oacute;digo-de-conducta: "Aplicando tu c&oacute;digo de conducta"
-  tus-responsabilidades-como-responsable-de-mantenimiento: "Tus responsabilidades como responsable de mantenimiento"
 order: 8
 image: /assets/images/cards/coc.png
 related:

--- a/_articles/es/starting-a-project.md
+++ b/_articles/es/starting-a-project.md
@@ -215,7 +215,7 @@ Para m&aacute;s informaci&oacute;n, entra a [Gu&iacute;a del C&oacute;digo de Co
 
 Adem&aacute;s de comunicar _c&oacute;mo_ esperas que se comporten los participantes, un c&oacute;digo de conducta tiende a describir a qui&eacute;n se aplican las expectativas, cuando apliquen, y qu&eacute; hacer si una violaci&oacute;n a las mismas ocurre.
 
-Como muchas licencias de c&oacute;digo abierto, existen est&aacute;ndares emergentes para c&oacute;digos de conducta para que no debas escribir uno propio. El [Contributor Covenant](https://www.contributor-covenant.org/) es un c&oacute;digo de conducta usado por [m&aacute;s de 40000 proyectos de c&oacute;digo abierto](https://www.contributor-covenant.org/adopters), incluyendo Kubernetes, Rails, and Swift. Debes estar preparado para redefinir el tuyo cuando sea necesario.
+Como muchas licencias de c&oacute;digo abierto, existen est&aacute;ndares emergentes para c&oacute;digos de conducta para que no debas escribir uno propio. El [Contributor Covenant](https://www.contributor-covenant.org/) es un c&oacute;digo de conducta usado por [m&aacute;s de 40000 proyectos de c&oacute;digo abierto](https://www.contributor-covenant.org/adopters/), incluyendo Kubernetes, Rails, and Swift. Debes estar preparado para redefinir el tuyo cuando sea necesario.
 
 Copia el texto directamente en el archivo CODE_OF_CONDUCT dentro de tu repositorio, en el directorio ra&iacute;z, y vinculalo desde tu README.
 

--- a/_articles/fr/code-of-conduct.md
+++ b/_articles/fr/code-of-conduct.md
@@ -8,7 +8,6 @@ toc:
   etablir-un-code-de-conduite: "Etablir un code de conduite"
   d&eacute;cider-comment-vous-allez-appliquer-votre-code-de-conduite: "D&eacute;cider comment vous allez appliquer votre code de conduite"
   appliquer-votre-code-de-conduite: "Appliquer votre code de conduite"
-  vos-responsabilités-en-tant-que-mainteneur: "Vos responsabilités en tant que mainteneur"
 order: 8
 image: /assets/images/cards/coc.png
 related:

--- a/_articles/fr/starting-a-project.md
+++ b/_articles/fr/starting-a-project.md
@@ -215,7 +215,7 @@ Pour plus d'informations, consultez notre [Code de conduite](../code-of-conduct/
 
 En plus de communiquer _comment_ vous souhaitez que les participants se comportent, un code de conduite a également tendance à décrire à qui s'appliquent ces attentes, quand ils s'appliquent, et que faire en cas de violation.
 
-Tout comme les licences open source, il existe également des normes émergentes pour les codes de conduite, vous n'avez donc pas besoin d'écrire les vôtres. Le [Contributor Covenant](https://contributor-covenant.org/)) est un code de conduite qui est utilisé par [plus de 40 000 projets open source](https://www.contributor-covenant.org/adopters) , y compris Kubernetes, Rails et Swift. Quel que soit le texte que vous utilisez, vous devez être prêt à appliquer votre code de conduite si nécessaire.
+Tout comme les licences open source, il existe également des normes émergentes pour les codes de conduite, vous n'avez donc pas besoin d'écrire les vôtres. Le [Contributor Covenant](https://contributor-covenant.org/)) est un code de conduite qui est utilisé par [plus de 40 000 projets open source](https://www.contributor-covenant.org/adopters/) , y compris Kubernetes, Rails et Swift. Quel que soit le texte que vous utilisez, vous devez être prêt à appliquer votre code de conduite si nécessaire.
 
 Collez le texte directement dans un fichier CODE_OF_CONDUCT dans votre repository. Conservez le fichier dans le répertoire racine de votre projet pour qu'il soit facile à trouver et liez-le à partir de votre fichier README.
 

--- a/_articles/id/code-of-conduct.md
+++ b/_articles/id/code-of-conduct.md
@@ -8,7 +8,6 @@ toc:
   membuat-kode-etik: "Membuat kode etik"
   menentukan-bagaimana-anda-akan-menerapkan-kode-etik: "Menentukan bagaimana Anda akan menerapkan kode etik"
   menerapkan-kode-etik: "Menerapkan kode etik"
-  tanggung-jawab-anda-sebagai-pengelola: "Tanggung jawab Anda sebagai pengelola"
 order: 8
 image: /assets/images/cards/coc.png
 related:

--- a/_articles/ko/code-of-conduct.md
+++ b/_articles/ko/code-of-conduct.md
@@ -8,7 +8,6 @@ toc:
   establishing-a-code-of-conduct: "행동강령 수립하기"
   deciding-how-youll-enforce-your-code-of-conduct: "행동강령을 어떻게 적용 할 것인지 결정하기"
   enforcing-your-code-of-conduct: "행동강령 지키기"
-  your-responsibilities-as-a-maintainer: "Your responsibilities as a maintainer"
 order: 8
 image: /assets/images/cards/coc.png
 related:

--- a/_articles/ko/starting-a-project.md
+++ b/_articles/ko/starting-a-project.md
@@ -215,7 +215,7 @@ README에 CONTRIBUTING 파일을 링크하면 더 많은 사람들이 볼 수 �
 
 행동강령은 참여자가 _어떻게_ 행동 할 것으로 기대하는지 의사 소통하는 것 외에도, 이러한 기대 사항이 적용되는 대상, 적용시기, 위반이 발생할 경우 수행 할 작업을 설명하는 경향이 있습니다.
 
-오픈소스 라이선스와 마찬가지로 행동강령에 대한 새로운 기준도 있으므로, 사용자가 직접 작성할 필요는 없습니다. [Contributor Covenant](https://www.contributor-covenant.org/)는 Kubernetes, Rails 및 Swift를 포함하여 [40,000개 이상의 오픈소스 프로젝트](https://www.contributor-covenant.org/adopters)에서 사용되는 행동 강령입니다. 어떤 텍스트를 사용하든 필요에 따라 행동강령을 시행 할 준비가 되어 있어야합니다.
+오픈소스 라이선스와 마찬가지로 행동강령에 대한 새로운 기준도 있으므로, 사용자가 직접 작성할 필요는 없습니다. [Contributor Covenant](https://www.contributor-covenant.org/)는 Kubernetes, Rails 및 Swift를 포함하여 [40,000개 이상의 오픈소스 프로젝트](https://www.contributor-covenant.org/adopters/)에서 사용되는 행동 강령입니다. 어떤 텍스트를 사용하든 필요에 따라 행동강령을 시행 할 준비가 되어 있어야합니다.
 
 텍스트를 저장소의 CODE_OF_CONDUCT 파일에 직접 붙여 넣으십시오. 프로젝트의 루트 디렉토리에 파일을 보관하여 찾기 쉽도록 하고, README에서 링크를 연결하십시오.
 

--- a/_articles/starting-a-project.md
+++ b/_articles/starting-a-project.md
@@ -215,7 +215,7 @@ For more information, check out our [Code of Conduct guide](../code-of-conduct/)
 
 In addition to communicating _how_ you expect participants to behave, a code of conduct also tends to describe who these expectations apply to, when they apply, and what to do if a violation occurs.
 
-Much like open source licenses, there are also emerging standards for codes of conduct, so you don't have to write your own. The [Contributor Covenant](https://contributor-covenant.org/) is a drop-in code of conduct that is used by [over 40,000 open source projects](https://www.contributor-covenant.org/adopters), including Kubernetes, Rails, and Swift. No matter which text you use, you should be prepared to enforce your code of conduct when necessary.
+Much like open source licenses, there are also emerging standards for codes of conduct, so you don't have to write your own. The [Contributor Covenant](https://contributor-covenant.org/) is a drop-in code of conduct that is used by [over 40,000 open source projects](https://www.contributor-covenant.org/adopters/), including Kubernetes, Rails, and Swift. No matter which text you use, you should be prepared to enforce your code of conduct when necessary.
 
 Paste the text directly into a CODE_OF_CONDUCT file in your repository. Keep the file in your project's root directory so it's easy to find, and link to it from your README.
 

--- a/_articles/zh-cn/code-of-conduct.md
+++ b/_articles/zh-cn/code-of-conduct.md
@@ -8,7 +8,6 @@ toc:
   establishing-a-code-of-conduct: "建立行为守则"
   deciding-how-youll-enforce-your-code-of-conduct: "决定你们如何执行行为守则"
   enforcing-your-code-of-conduct: "执行你们的行为守则"
-  维护者的责任和义务: "维护者的责任和义务"
 order: 8
 image: /assets/images/cards/coc.png
 related:

--- a/_articles/zh-cn/starting-a-project.md
+++ b/_articles/zh-cn/starting-a-project.md
@@ -215,7 +215,7 @@ related:
 
 除了传达你期待参与者**如何**行动，行为规范也倾向于描述这些期待针对谁，适用于何时，以及对于违规行为的处理方法。
 
-就像开源许可证一样，有现成的行为规范，所以你不必自己编写。[贡献者公约](https://www.contributor-covenant.org/)是一个行之有效的行为规范，已经被用在[超过4000个开源项目](https://www.contributor-covenant.org/adopters)，包括 Kubernetes，Rails，以及 Swift。无论你使用哪一种，你都应该准备好在必要时执行行为规范。
+就像开源许可证一样，有现成的行为规范，所以你不必自己编写。[贡献者公约](https://www.contributor-covenant.org/)是一个行之有效的行为规范，已经被用在[超过4000个开源项目](https://www.contributor-covenant.org/adopters/)，包括 Kubernetes，Rails，以及 Swift。无论你使用哪一种，你都应该准备好在必要时执行行为规范。
 
 将文本直接粘贴到项目存储库中的 CODE_OF_CONDUCT 文件中。将文件保存在项目的根目录中，以便轻松找到，并从 README 中链接到它。
 


### PR DESCRIPTION
Reverts github/opensource.guide#685