### PR TITLE
Fix back to the index page link for non-English languages

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -19,7 +19,7 @@
     <div class="float-sm-left pl-3 breadcrumb">
       <p class="my-0 py-3 py-sm-4 text-gray">
         {% if page.lang != 'en' %}
-        <a href="/{{ page.lang }}" class="text-gray">{{ site.title }}</a>
+        <a href="/{{ page.lang }}/" class="text-gray">{{ site.title }}</a>
         {% else %}
         <a href="/" class="text-gray">{{ site.title }}</a>
         {% endif %}

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -18,7 +18,11 @@
     {% if page.layout != 'index' %}
     <div class="float-sm-left pl-3 breadcrumb">
       <p class="my-0 py-3 py-sm-4 text-gray">
+        {% if page.lang != 'en' %}
+        <a href="/{{ page.lang }}" class="text-gray">{{ site.title }}</a>
+        {% else %}
         <a href="/" class="text-gray">{{ site.title }}</a>
+        {% endif %}
       </p>
     </div>
     {% endif %}


### PR DESCRIPTION
- [x] Have you followed the [contributing guidelines](https://github.com/github/opensource.guide/blob/master/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value to the Guides?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

-----

Current `nav.html` only goes to `/` (without lang) even in non-English article pages. (like <https://opensource.guide/ko/starting-a-project/>)
This patch appends `page.lang` path in ‘Back to the index’ link to keep users inside translated pages.