### PR TITLE
Better word-break style for Korean

### DIFF
--- a/assets/css/custom.scss
+++ b/assets/css/custom.scss
@@ -20,6 +20,11 @@ blockquote {
   }
 }
 
+.lead,
+.alt-lead {
+  word-break: keep-all;
+}
+
 .pquote {
   border: $border;
   padding: $spacer-3;
@@ -172,6 +177,7 @@ blockquote {
     font-size: 21px;
     font-weight: $font-weight-light;
     color: $gray;
+    word-break: keep-all;
     @include breakpoint(md) { font-size: 24px; }
     @include breakpoint(lg) { font-size: 26px; }
 


### PR DESCRIPTION
- [x] Have you followed the [contributing guidelines](https://github.com/github/opensource.guide/blob/master/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value to the Guides?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

-----

This patch prevents breaking within Korean words, especially for heading text. This improves readability for Korean and has almost no impact on other languages. Or could you provide a way to add styles for specific languages?

Before:
![screen shot 2018-10-02 at 3 23 49 am](https://user-images.githubusercontent.com/579366/46309169-88a5e400-c5f6-11e8-82b5-bf1181f6ad88.png)

After:
![screen shot 2018-10-02 at 3 23 38 am](https://user-images.githubusercontent.com/579366/46309179-93f90f80-c5f6-11e8-8ac8-feab18b4ee5c.png)


XRef: https://stackoverflow.com/questions/26044322/dealing-with-korean-text-breaking-words