### PR TITLE
ignore drupal.org url that obtains 403 in tests but works

### DIFF
--- a/script/html-proofer
+++ b/script/html-proofer
@@ -5,6 +5,7 @@ require "html-proofer"
 
 url_ignores = [
   "https://okdistribute.xyz/post/okf-de",
+  "https://www.drupal.org/community-initiatives/drupal-core/usability"
 ]
 
 HTMLProofer::Runner.new(


### PR DESCRIPTION
- [x] Have you followed the [contributing guidelines](https://github.com/github/opensource.guide/blob/master/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value to the Guides?

As noted at https://github.com/github/opensource.guide/pull/763#issuecomment-439726875

> I think the dupal.org site must be doing some kind of throttling, but I can't tell what -- the site works for me from a web browser or wget, but not curl or tests, and changing the user agent doesn't help. So ignoring for now.

This PR has the test do the ignoring, rather than me ignoring the test's failure report.
