### PR TITLE
Add revenue stream example: metafizzy.co

### DIFF
--- a/_articles/getting-paid.md
+++ b/_articles/getting-paid.md
@@ -138,6 +138,7 @@ Depending on your project, you may be able to charge for commercial support, hos
 * **[Sidekiq](https://github.com/mperham/sidekiq)** offers paid versions for additional support
 * **[Travis CI](https://github.com/travis-ci)** offers paid versions of its product
 * **[Ghost](https://github.com/TryGhost/Ghost)** is a nonprofit with a paid managed service
+* **[Metafizzy](https://metafizzy.co/)** products are free for open source use and paid for commercial use
 
 Some popular projects, like [npm](https://github.com/npm/npm) and [Docker](https://github.com/docker/docker), even raise venture capital to support their business growth.
 


### PR DESCRIPTION
Metafizzy.co products have three kinds of licenses: open-source, commercial, and OEM.

Example products:
* [Isotope License](https://isotope.metafizzy.co/license.html)
* [Flickity License](https://flickity.metafizzy.co/license.html)

It's an interesting pricing model that could sustain open source products that don't fit into the "paid support" or "additional features" revenue streams.

- [x] Have you followed the [contributing guidelines](https://github.com/github/opensource.guide/blob/master/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value to the Guides?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

-----
