### PR TITLE
Move `word-break: keep-all` within Korean selector

### DIFF
--- a/assets/css/custom.scss
+++ b/assets/css/custom.scss
@@ -20,11 +20,6 @@ blockquote {
   }
 }
 
-.lead,
-.alt-lead {
-  word-break: keep-all;
-}
-
 .pquote {
   border: $border;
   padding: $spacer-3;
@@ -177,7 +172,6 @@ blockquote {
     font-size: 21px;
     font-weight: $font-weight-light;
     color: $gray;
-    word-break: keep-all;
     @include breakpoint(md) { font-size: 24px; }
     @include breakpoint(lg) { font-size: 26px; }
 
@@ -239,4 +233,12 @@ blockquote {
 
 .little-illo {
   max-height: 50px;
+}
+
+*:lang(ko) {
+  .lead,
+  .alt-lead,
+  h2 + p {
+    word-break: keep-all;
+  }
 }


### PR DESCRIPTION
- [x] Have you followed the [contributing guidelines](https://github.com/github/opensource.guide/blob/master/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value to the Guides?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

-----
I introduced `word-break: keep-all` for better readability for Korean pages by #714. But this causes #789. By applying this patch, `word-break: keep-all` will affect only Korean pages.
XRef: https://www.w3schools.com/cssref/sel_lang.asp

Korean page:
<img width="685" alt="screen shot 2018-12-29 at 12 30 55 pm" src="https://user-images.githubusercontent.com/579366/50533062-d2568a00-0b65-11e9-8580-bfd21782211d.png">

Chinese page:
<img width="737" alt="screen shot 2018-12-29 at 12 31 15 pm" src="https://user-images.githubusercontent.com/579366/50533064-d71b3e00-0b65-11e9-8658-5c3b9f88737a.png">
