### PR TITLE
Add PR requirement to enable GitHub pages 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,6 @@
 - [ ] Have you followed the [contributing guidelines](https://github.com/github/opensource.guide/blob/master/CONTRIBUTING.md)?
 - [ ] Have you explained what your changes do, and why they add value to the Guides?
+- [ ] Have you selected <keyboard>`Enable GitHub Pages`</keyboard> to trigger a pages build for this PR?
 
 **Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 - [ ] Have you followed the [contributing guidelines](https://github.com/github/opensource.guide/blob/master/CONTRIBUTING.md)?
 - [ ] Have you explained what your changes do, and why they add value to the Guides?
-- [ ] Have you selected <keyboard>`Enable GitHub Pages`</keyboard> to trigger a pages build for this PR?
+- [ ] Have you enabled GitHub Pages Previews by pressing <keyboard>`Enable GitHub Pages`</keyboard> on the right sidebar to trigger a pages build for this PR?
 
 **Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**
 


### PR DESCRIPTION
This is a new required check and needs to be done to each PR for the checks to pass.