### PR TITLE
Got rid of the archived repository

### DIFF
--- a/_articles/best-practices.md
+++ b/_articles/best-practices.md
@@ -239,7 +239,6 @@ The good news about maintaining a popular project is that other maintainers have
 There are a [variety of tools available](https://github.com/showcases/tools-for-open-source) to help automate some aspects of maintenance work. A few examples:
 
 * [semantic-release](https://github.com/semantic-release/semantic-release) automates your releases
-* [mention-bot](https://github.com/facebook/mention-bot) mentions potential reviewers for pull requests
 * [Danger](https://github.com/danger/danger) helps automate code review
 
 For bug reports and other common contributions, GitHub has [Issue Templates and Pull Request Templates](https://github.com/blog/2111-issue-and-pull-request-templates), which you can create to streamline the communication you receive. @TalAter made a [Choose Your Own Adventure guide](https://www.talater.com/open-source-templates/#/) to help you write your issue and PR templates.


### PR DESCRIPTION
- [x] Have you followed the [contributing guidelines](https://github.com/github/opensource.guide/blob/master/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value to the Guides?
- [x] Have you enabled GitHub Pages Previews by pressing <keyboard>`Enable GitHub Pages`</keyboard> on the right sidebar to trigger a pages build for this PR?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

-----
This is a change that gets rid of a link to a archived repository from the Best practices guide.