### PR TITLE
Debug language switch navigation link-error

### DIFF
--- a/assets/js/locale.js
+++ b/assets/js/locale.js
@@ -9,7 +9,7 @@ function loadLanguage(lang) {
   if (lang === "en") {
     url = base_pathname
   } else {
-    url = base_pathname + lang
+    url = "/" + lang + base_pathname
   }
   window.location.assign(url);
 }


### PR DESCRIPTION
- [x] Have you followed the [contributing guidelines](https://github.com/github/opensource.guide/blob/master/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value to the Guides?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

-----
By previews code, when I were at https://opensource.guide/zh-cn/how-to-contribute/ or any other language page except English, if I want to switch to traditional Chinese language, after I click the bottom on the top right corner of the page,  https://opensource.guide/how-to-contribute/zh-tw/  is open instead of https://opensource.guide/zh-tw/how-to-contribute/. The former is wrong but the new one is right.

I fixed this bug.