### PR TITLE
Add Tidelift subscription

### DIFF
--- a/_articles/getting-paid.md
+++ b/_articles/getting-paid.md
@@ -131,6 +131,7 @@ A few examples of sponsored projects include:
 * **[Vue](https://github.com/vuejs/vue)** is [funded through Patreon](https://github.com/open-source/stories/yyx990803)
 * **[Ruby Together](https://rubytogether.org/),** a nonprofit organization that pays for work on [bundler](https://github.com/bundler/bundler), [RubyGems](https://github.com/rubygems/rubygems), and other Ruby infrastructure projects
 
+
 ### Create a revenue stream
 
 Depending on your project, you may be able to charge for commercial support, hosted options, or additional features. A few examples include:
@@ -138,6 +139,7 @@ Depending on your project, you may be able to charge for commercial support, hos
 * **[Sidekiq](https://github.com/mperham/sidekiq)** offers paid versions for additional support
 * **[Travis CI](https://github.com/travis-ci)** offers paid versions of its product
 * **[Ghost](https://github.com/TryGhost/Ghost)** is a nonprofit with a paid managed service
+* **[Material-UI](https://github.com/mui-org/material-ui)** offers a [managed open source solution](https://tidelift.com/subscription/pkg/npm-material-ui?utm_source=material_ui&utm_medium=referral&utm_campaign=homepage) [through Tidelift](https://tidelift.com/about/lifter)
 
 Some popular projects, like [npm](https://github.com/npm/npm) and [Docker](https://github.com/docker/docker), even raise venture capital to support their business growth.
 


### PR DESCRIPTION
Added Material-UI and the Tidelift subscription under examples of managed open source solutions. Tidelift is a partner of GitHub through GitHub Sponsors so it makes sense to have the option represented in a GitHub guide to getting paid for open source.  Unlike the other examples under managed open source solutions, Tidelift doesn't require a maintainer to set up their own managed solution from scratch, so it adds value to the guide because it's a solution that's more accessible to the average maintainer.

- [x] Have you followed the [contributing guidelines](https://github.com/github/opensource.guide/blob/master/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value to the Guides?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

-----
