### PR TITLE
Updated point 4 and 5 in translations.md (Issue #1175)

### DIFF
--- a/docs/translations.md
+++ b/docs/translations.md
@@ -11,8 +11,8 @@ If there's not, then today is your day to lead this effort! Here's how to start:
 1. [Fork this repository](https://github.com/github/opensource.guide/fork)
 1. Create a new branch for your translation work e.g. `es`.
 1. Copy `_data/locales/en.yml` to your target language file e.g. `_data/locales/es.yml` and translate all the strings.
-1. Create a new directory in `_articles/` for your language e.g. `_articles/es/`, copy each guide from `_articles/` into that folder and translate the content in each guide, except for the field names in the front matter between the `---`s at the top of each file, e.g., `title:` should be unchanged.
-1. Copy `index.html` to your target language index file e.g. `[_articles/es/index.html](https://github.com/github/opensource.guide/blob/master/_articles/es/index.html)` and update the `lang:` and add the `permalink:` field. Remove the `toc:` fields (they are only used for English).
+1. Create a new directory in `_articles/` for your language e.g. `_articles/es/`, copy each guide from `_articles/` into that folder and translate the content in each guide, except for the field names in the front matter between the `---`s at the top of each file, e.g., `title:` should remain unchanged. Remove the `toc:` fields (they are only used for English).
+1. Copy `index.html` to your target language index file e.g. `[_articles/es/index.html](https://github.com/github/opensource.guide/blob/master/_articles/es/index.html)` and update the `lang:` and add the `permalink:` fields. Example: `lang: es` and `permalink: /es/`. All other fields' values must remain unchanged.
 1. Run `script/test` and make sure there are no failures with your translation files. Note that you may need to fix broken links.
 1. Send a pull request.
 


### PR DESCRIPTION
1. As per issue #1175 toc fields are not present in index.html but rather in articles. I have changed the points accordingly.

- [✓] Have you followed the [contributing guidelines](https://github.com/github/opensource.guide/blob/master/CONTRIBUTING.md)?
- [✓] Have you explained what your changes do, and why they add value to the Guides?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

-----
