### PR TITLE
Revert "Bump yell from 2.2.0 to 2.2.1"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,7 +248,7 @@ GEM
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
-    yell (2.2.1)
+    yell (2.2.0)
     zeitwerk (2.2.2)
 
 PLATFORMS


### PR DESCRIPTION
Reverts github/opensource.guide#1269