### PR TITLE
Fix link syntax in FR starting-a-project page

### DIFF
--- a/_articles/fr/starting-a-project.md
+++ b/_articles/fr/starting-a-project.md
@@ -39,7 +39,7 @@ Par comparaison, un processus de source fermée serait de se rendre dans un rest
   </p>
 </aside>
 
-[Il y a plein de raisons] (https://ben.balter.com/2015/11/23/why-open-source/) pour une personne ou une organisation de vouloir ouvrir un projet. Par exemple :
+[Il y a plein de raisons](https://ben.balter.com/2015/11/23/why-open-source/) pour une personne ou une organisation de vouloir ouvrir un projet. Par exemple :
 
 * **Collaboration :** Les projets open source peuvent accepter des changements de n'importe qui dans le monde. [Exercism](https://github.com/exercism/), par exemple, est une plate-forme d'exercices de programmation avec plus de 350 contributeurs.
 


### PR DESCRIPTION
- [X] Have you followed the [contributing guidelines](https://github.com/github/opensource.guide/blob/master/CONTRIBUTING.md)?
- [X] Have you explained what your changes do, and why they add value to the Guides?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

-----
Hi,

On this page: https://opensource.guide/fr/starting-a-project/ the rendering of the link is wrong because an extra space is present, this PR fixes that.

Regards