### PR TITLE
Revert "Bump dnsruby from 1.61.2 to 1.61.3"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
     commonmarker (0.17.13)
       ruby-enum (~> 0.5)
     concurrent-ruby (1.1.5)
-    dnsruby (1.61.3)
+    dnsruby (1.61.2)
       addressable (~> 2.5)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)


### PR DESCRIPTION
Reverts github/opensource.guide#1061