### PR TITLE
Applying translations into header (class=h00-mktg)

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -2,13 +2,18 @@
 layout: default
 ---
 {% assign t = site.data.locales[page.lang][page.lang] %}
+{% if page.title %}
+  {% assign header = page.title %}
+{% else %}
+  {% assign header = site.title %}
+{% endif %}
 {% include nav.html %}
 
 <div class="bg-gray-light">
 
   <header class="py-4 py-md-6">
     <div class="container-lg p-responsive mx-auto text-center pt-6">
-      <h1 class="h00-mktg">{{ site.title }}</h1>
+      <h1 class="h00-mktg">{{ header }}</h1>
       <p class="lead-mktg text-gray mb-md-5 col-md-8 mx-auto">
         {{ t.index.lead }}
       </p>


### PR DESCRIPTION
- [x] Have you followed the [contributing guidelines](https://github.com/github/opensource.guide/blob/master/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value to the Guides?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

-----

There were not any translations in h1 header tag with class="h00-mktg". (Only "Open Source Guides")
I used page.title (if exists) variable in order to apply translations into header section.