### PR TITLE
Add google-site-verification meta tag

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="google-site-verification" content="c1kuD-K2HIVF635lypcsWPoD4kilo5-jA_wBFyT4uMY" />
   <link rel="icon" type="image/x-icon" href="https://github.githubassets.com/favicon.ico">
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,300i,400,400i,700,700i" rel="stylesheet">
   <link href="{{ "/assets/css/index.css" | relative_url }}" rel="stylesheet">


### PR DESCRIPTION
Adds the following `meta` tag for Google Search Console verification:

```html
<meta name="google-site-verification" content="c1kuD-K2HIVF635lypcsWPoD4kilo5-jA_wBFyT4uMY" />
```

/cc @SEOGoddess 