### PR TITLE
Adding Gitpod configuration

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,50 @@
+FROM debian:stable-slim
+
+### base ###
+RUN apt-get update \
+    && apt-get install -yq \
+        zip unzip bash-completion build-essential htop \
+        less curl locales man-db nano software-properties-common \
+        sudo time vim multitail lsof \ 
+        libxml2-dev zlib1g-dev\
+    && locale-gen en_US.UTF-8 \
+    && mkdir /var/lib/apt/dazzle-marks \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y locales
+
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
+
+ENV LANG=en_US.UTF-8
+
+### Git ###
+RUN  apt-get update \
+    && apt-get install -yq git-all \
+    && rm -rf /var/lib/apt/lists/*
+
+### Gitpod user ###
+# '-l': see https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
+RUN useradd -l -u 33333 -G sudo -md /home/gitpod -s /bin/bash -p gitpod gitpod \
+    # passwordless sudo for users in the 'sudo' group
+    && sed -i.bkp -e 's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' /etc/sudoers
+ENV HOME=/home/gitpod
+WORKDIR $HOME
+# custom Bash prompt
+RUN { echo && echo "PS1='\[\e]0;\u \w\a\]\[\033[01;32m\]\u\[\033[00m\] \[\033[01;34m\]\w\[\033[00m\] \\\$ '" ; } >> .bashrc
+
+### Gitpod user (2) ###
+USER gitpod
+# use sudo so that user does not get sudo usage info on (the first) login
+RUN sudo echo "Running 'sudo' for Gitpod: success"
+
+### Ruby ###
+USER root
+RUN apt-get update \
+    && apt-get install -yq ruby-full \
+    && bash -lc "gem install bundler --no-document \
+        && gem install solargraph --no-document \
+        && gem install jekyll --no-document"
+
+USER gitpod

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,8 @@
+ports:
+  - port: 4000
+    onOpen: open-browser
+tasks:
+  - init: bundle update && bundle install
+    command: bundle exec jekyll serve --host=0.0.0.0
+image:
+  file: .gitpod.Dockerfile

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.3.1)
+    activesupport (6.0.3.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -17,8 +17,8 @@ GEM
     commonmarker (0.17.13)
       ruby-enum (~> 0.5)
     concurrent-ruby (1.1.6)
-    dnsruby (1.61.3)
-      addressable (~> 2.5)
+    dnsruby (1.61.4)
+      simpleidn (~> 0.1)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
@@ -28,7 +28,7 @@ GEM
     execjs (2.7.0)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
-    ffi (1.12.2)
+    ffi (1.13.1)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
     github-pages (206)
@@ -80,7 +80,7 @@ GEM
       octokit (~> 4.0)
       public_suffix (~> 3.0)
       typhoeus (~> 1.3)
-    html-pipeline (2.12.3)
+    html-pipeline (2.13.0)
       activesupport (>= 2)
       nokogiri (>= 1.4)
     html-proofer (3.15.3)
@@ -212,14 +212,14 @@ GEM
       jekyll-seo-tag (~> 2.1)
     minitest (5.14.1)
     multipart-post (2.1.1)
-    nokogiri (1.10.9)
+    nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     nokogumbo (2.0.2)
       nokogiri (~> 1.8, >= 1.8.4)
     octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    parallel (1.19.1)
+    parallel (1.19.2)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (3.1.1)
@@ -241,6 +241,8 @@ GEM
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
+    simpleidn (0.1.1)
+      unf (~> 0.1.4)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     thread_safe (0.3.6)
@@ -248,9 +250,12 @@ GEM
       ethon (>= 0.9.0)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
     yell (2.2.2)
-    zeitwerk (2.3.0)
+    zeitwerk (2.4.0)
 
 PLATFORMS
   ruby
@@ -261,4 +266,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   2.1.2
+   2.1.4

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Open Source Guides
-
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/github/opensource.guide)
 [![Build Status](https://github.com/github/opensource.guide/workflows/GitHub%20Actions%20CI/badge.svg)](https://github.com/github/opensource.guide/actions)
 
 Open Source Guides (https://opensource.guide/) are a collection of resources for individuals, communities, and companies who want to learn how to run and contribute to an open source project.


### PR DESCRIPTION
- [x] Have you followed the [contributing guidelines](https://github.com/github/opensource.guide/blob/HEAD/CONTRIBUTING.md)?

I know that the type of contribution I bring is not what you are currently looking for, I am working on setting up your articles in an eBook format and in this context, I have set up a Gitpod environment to be able to contribute from any machine. 

- [x] Have you explained what your changes do, and why they add value to the Guides?

In order to allow everyone to contribute without having to install the whole Jekyll stack on their workstations, I propose you to use Gitpod which allows you to set up an environment in the cloud and thus be able to work on the site from anywhere, on any machine and for free.

Hoping that the implementation of this will improve the experience of the contributors thanks to an easy to set up working environment in one click.

In this environment specially designed to contribute to sites based on Jekyll technology, the environment set up allows an automatic start of the site in previw mode and to visualize live the changes that are made.

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

-----
