### PR TITLE
Always load mc-validate.js over HTTPS

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,7 +9,7 @@
     </main>
 
     <script src="{{ "/assets/js/index.js" | relative_url }}"></script>
-    <script type="text/javascript" src="//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js"></script>
+    <script type="text/javascript" src="https://s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js"></script>
     <script type="text/javascript">(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
   </body>
 </html>


### PR DESCRIPTION
URLS without a protocol are an anti-pattern. This is safer and faster.

- [x] Have you followed the [contributing guidelines](https://github.com/github/opensource.guide/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value to the Guides?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

-----
