### PR TITLE
Add GitHub Actions to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,16 @@ updates:
     separator: "-"
   open-pull-requests-limit: 99
   rebase-strategy: disabled
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "10:00"
+    timezone: Europe/Vienna
+  pull-request-branch-name:
+    separator: "-"
+  open-pull-requests-limit: 99
+  rebase-strategy: disabled
 - package-ecosystem: npm
   directory: "/"
   schedule:


### PR DESCRIPTION
Dependabot has the ability to keep GitHub Actions used in `.github/workflows` up to date.
See https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot#example-dependabotyml-file-for-github-actions

- [x] Have you followed the [contributing guidelines](https://github.com/github/opensource.guide/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value to the Guides?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

-----
