### PR TITLE
script/html-proofer: ignore more URLs.

### DIFF
--- a/script/html-proofer
+++ b/script/html-proofer
@@ -7,7 +7,9 @@ url_ignores = [
   "https://okdistribute.xyz/post/okf-de",
   "https://www.drupal.org/community-initiatives/drupal-core/usability",
   "https://scripts.sil.org/ofl",
+  "https://the-orbit.net/almostdiamonds/2014/04/10/so-youve-got-yourself-a-policy-now-what/",
   %r{^https?://twitter\.com/},
+  %r{^https?://kickstarter\.com/},
 ]
 
 HTMLProofer::Runner.new(


### PR DESCRIPTION
These are causing CI failures: https://github.com/github/opensource.guide/pull/2424/checks?check_run_id=2712132660#step:7:37