### PR TITLE
script/html-proofer: ignore more Kickstarter URLs.

### DIFF
--- a/script/html-proofer
+++ b/script/html-proofer
@@ -9,7 +9,7 @@ url_ignores = [
   "https://scripts.sil.org/ofl",
   "https://the-orbit.net/almostdiamonds/2014/04/10/so-youve-got-yourself-a-policy-now-what/",
   %r{^https?://twitter\.com/},
-  %r{^https?://kickstarter\.com/},
+  %r{^https?://(www\.)?kickstarter\.com/},
 ]
 
 HTMLProofer::Runner.new(


### PR DESCRIPTION
These are failing in HTML Proofer but working in Safari.