### PR TITLE
Exclude package-lock.json

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,7 @@ exclude:
   - Gemfile*
   - node_modules
   - package.json
+  - package-lock.json
   - Rakefile
   - README.md
   - script


### PR DESCRIPTION
Removes [public-facing `package-lock.json`](https://opensource.guide/package-lock.json) addressing https://github.com/github/security/issues/4204.
File can always be seen in this repo of course 😉 