### PR TITLE
Fix stale action by replacing issue with pull request

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-name: Mark stale issues
+name: Mark stale PRs
 on:
   workflow_dispatch:
   schedule:
@@ -10,13 +10,13 @@ jobs:
     steps:
     - uses: actions/stale@v3
       with:
-        stale-issue-message: >
-          This issue has been automatically marked as stale because it has not
+        stale-pr-message: >
+          This pull request has been automatically marked as stale because it has not
           had recent activity. It will be closed if no further activity occurs.
           Thank you for your contributions.
-        stale-issue-label: "stale"
-        exempt-issue-labels: "pinned,security"
-        days-before-issue-stale: 30
-        days-before-issue-close: 7
+        stale-pr-label: "stale"
+        exempt-pr-labels: "pinned,security"
+        days-before-pr-stale: 30
+        days-before-pr-close: 7
         ascending: true
         operations-per-run: 100


### PR DESCRIPTION
Follow up to https://github.com/github/opensource.guide/pull/2534, I realize we wanted the action to mark **pull requests** as stale, not **issues** (which aren't supported in this repo)