### PR TITLE
feat: Add node_modules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/node_modules
 .DS_Store
 .asset-downloads
 .bundle


### PR DESCRIPTION
## Fixes minor issue

adds node_modules in .gitignore file.

All necessary information about packages is mentioned in the package.json file. 

- [x] Have you followed the [contributing guidelines](https://github.com/github/opensource.guide/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value to the Guides?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

-----
