### PR TITLE
Revert "Bump actions/setup-node from 2.5.0 to 2.5.1"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/setup-ruby@v1.1.3
 
     - name: Set up Node
-      uses: actions/setup-node@v2.5.1
+      uses: actions/setup-node@v2.5.0
 
     - name: Restore bundler cache
       uses: actions/cache@v2.1.7


### PR DESCRIPTION
Reverts github/opensource.guide#2694