### PR TITLE
Lock html-proofer version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source "https://rubygems.org"
 gem "github-pages", group: :jekyll_plugins
 
 group :test do
-  gem "html-proofer"
+  gem "html-proofer", "~> 3.19.4"
   gem "rake"
 end


### PR DESCRIPTION
- [x] Have you followed the [contributing guidelines](https://github.com/github/opensource.guide/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value to the Guides?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

-----

html-proofer has had a few 4.x releases that are [breaking CI builds](https://github.com/github/opensource.guide/runs/7510507292?check_suite_focus=true). I tried a trivial configuration fix but got thousands of failures, which are probably spurious? Let's lock the html-proofer version for now.