### PR TITLE
Make tests faster

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,8 @@ jobs:
 
     - name: Bootstrap
       run: script/bootstrap
+      env:
+        SKIP_BUNDLER: true
 
     - name: Tests
       run: script/test

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -4,7 +4,7 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-if [[ -z "${SKIP_BUNDLE}" ]]; then
+if [[ -z "${SKIP_BUNDLER}" ]]; then
   echo "==> Installing gem dependencies…"
   bundle check --path vendor/gems &>/dev/null || {
     time bundle install --binstubs bin --path vendor/gems

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -4,10 +4,12 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-echo "==> Installing gem dependencies…"
-bundle check --path vendor/gems &>/dev/null || {
-  time bundle install --binstubs bin --path vendor/gems
-}
+if [[ -z "${SKIP_BUNDLE}" ]]; then
+  echo "==> Installing gem dependencies…"
+  bundle check --path vendor/gems &>/dev/null || {
+    time bundle install --binstubs bin --path vendor/gems
+  }
+fi
 
 echo "==> Installing node dependencies…"
 npm install


### PR DESCRIPTION
We don't need to bundle install twice, so skip it for actions