### PR TITLE
Remove sourcesort.com

### DIFF
--- a/_articles/fa/how-to-contribute.md
+++ b/_articles/fa/how-to-contribute.md
@@ -224,7 +224,6 @@ related:
 * [Up For Grabs](https://up-for-grabs.net/)
 * [Contributor-ninja](https://contributor.ninja)
 * [First Contributions](https://firstcontributions.github.io)
-* [SourceSort](https://www.sourcesort.com/)
 
 ### بررسی چک لیست قبل از مشارکت در پروژه‌ی متن باز
 


### PR DESCRIPTION
Remove sourcesort.com as the domain has expired and is now for sale.

- [x] Have you followed the [contributing guidelines](https://github.com/github/opensource.guide/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value to the Guides?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

-----
