### PR TITLE
feat: make the nav stick to the top of the pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,5 @@ group :test do
   gem "html-proofer", "~> 3.19.4"
   gem "rake"
 end
+
+gem "webrick", "~> 1.8"

--- a/assets/css/custom.scss
+++ b/assets/css/custom.scss
@@ -62,6 +62,16 @@ blockquote {
   line-height: 0;
 }
 
+nav.main-nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 10; 
+  background-color: #fff; 
+  transition: all 0.3s ease-in-out;
+}
+
 .main-links {
   a {
     &:hover {


### PR DESCRIPTION
- [*] Have you followed the [contributing guidelines] (https://github.com/github/opensource.guide/blob/HEAD/CONTRIBUTING.md)?yes
- [*] Have you explained what your changes do, and why they add value to the Guides?yes

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

-----
 Enable Sticky Navigation Bar

**Description:**

This pull request introduces a sticky navigation bar to the Open Source Guide website. It implements the following:

* Fixed positioning for the navigation bar, ensuring it remains visible at the top of the screen while scrolling.
* This change improves user experience by providing easier access to navigation options throughout the website.