### PR TITLE
Fix test failure caused by untranslated internal link

### DIFF
--- a/_articles/pcm/best-practices.md
+++ b/_articles/pcm/best-practices.md
@@ -149,7 +149,7 @@ If you dey find people wey go fit help, start to ask around.
 
 One way to get new contributors be to [label issues wey dey simple for beginners to work on](https://help.github.com/en/articles/helping-new-contributors-find-your-project-with-labels). GitHub go show these issues for different places for the platform, e go make them dey easier to see.
 
-When you see new contributors wey dey make repeated contributions, make you acknowledge their work and give them more responsibility. Write down how other people fit grow into leadership roles if them wan. Make you encourage others to [share ownership of the project](../building-community/#share-ownership-of-your-project) because e fit reduce your own workload, just like @lmccart find out for her project, [p5.js](https://github.com/processing/p5.js).
+When you see new contributors wey dey make repeated contributions, make you acknowledge their work and give them more responsibility. Write down how other people fit grow into leadership roles if them wan. Make you encourage others to [share ownership of the project](../building-community/#share-the-person-waeh-get-your-project) because e fit reduce your own workload, just like @lmccart find out for her project, [p5.js](https://github.com/processing/p5.js).
 
 <aside markdown="1" class="pquote">
   <img src="https://avatars.githubusercontent.com/lmccart?s=180" class="pquote-avatar" alt="avatar">

--- a/_articles/pcm/leadership-and-governance.md
+++ b/_articles/pcm/leadership-and-governance.md
@@ -73,7 +73,7 @@ Once you've established leadership roles, don't forget to document how people ca
 
 Tools like [Vossibility](https://github.com/icecrime/vossibility-stack) can help you publicly track who is (or isn't) making contributions to the project. Documenting this information avoids the community perception that maintainers are a clique that makes its decisions privately.
 
-Finally, if your project is on GitHub, consider moving your project from your personal account to an Organization and adding at least one backup admin. [GitHub Organizations](https://help.github.com/articles/creating-a-new-organization-account/) make it easier to manage permissions and multiple repositories and protect your project's legacy through [shared ownership](../building-community/#share-ownership-of-your-project).
+Finally, if your project is on GitHub, consider moving your project from your personal account to an Organization and adding at least one backup admin. [GitHub Organizations](https://help.github.com/articles/creating-a-new-organization-account/) make it easier to manage permissions and multiple repositories and protect your project's legacy through [shared ownership](../building-community/#share-the-person-waeh-get-your-project).
 
 ## When should I give someone commit access?
 


### PR DESCRIPTION
Prior to this change the tests would fail with:

Checking 358 external links...
Ran on 300 files!
- _site/pcm/best-practices/index.html
  *  linking to internal hash #share-ownership-of-your-project that does not exist (line 557)
       <a href="../building-community/#share-ownership-of-your-project">share ownership of the project</a>

This fixes the internal anchor to match the translated header text.
