### PR TITLE
Fix data structure problem in bg

### DIFF
--- a/_data/locales/bg.yml
+++ b/_data/locales/bg.yml
@@ -1,4 +1,4 @@
-en:
+bg:
   locale_name: Български
   nav:
     about: Относно нас


### PR DESCRIPTION
Fix a problem with the data structure in the bg.yml datafile

The top level key was still `en` from the english template file, causing the top nav/language chooser not to render correctly
