### PR TITLE
fix: use SHAs for GitHub Actions instead of tags

### DIFF
--- a/.github/workflows/jekyll-preview.yml
+++ b/.github/workflows/jekyll-preview.yml
@@ -5,24 +5,20 @@
 
 # Sample workflow for building and deploying a Jekyll site to GitHub Pages
 name: Deploy Jekyll site to Pages preview environment
-
 on:
   # Runs on pull requests targeting the default branch
   pull_request_target:
     branches: ["main"]
-
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
-
 # Allow only one concurrent deployment per PR, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: 'pages-preview @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: false
-
 jobs:
   # Build job
   build:
@@ -32,22 +28,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
         with:
           # For PRs make sure to checkout the PR branch
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
+        uses: actions/jekyll-build-pages@b178f9334b208360999a0a57b523613563698c66 # v1
         with:
           source: ./
           destination: ./_site
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v3
-
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
   # Deployment job
   deploy:
     environment:
@@ -63,6 +58,6 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
         with:
           preview: 'true'

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -5,45 +5,39 @@
 
 # Sample workflow for building and deploying a Jekyll site to GitHub Pages
 name: Deploy Jekyll site to Pages
-
 on:
   # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
-
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
-
 jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
+        uses: actions/jekyll-build-pages@b178f9334b208360999a0a57b523613563698c66 # v1
         with:
           source: ./
           destination: ./_site
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v3
-
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
   # Deployment job
   deploy:
     environment:
@@ -54,4 +48,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,21 +2,19 @@ name: Mark stale PRs
 on:
   workflow_dispatch:
   schedule:
-  - cron: "0 12 * * *"
-
+    - cron: "0 12 * * *"
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v9
-      with:
-        stale-pr-message: >
-          This pull request has been automatically marked as stale because it has not
-          had recent activity. It will be closed if no further activity occurs.
-          Thank you for your contributions.
-        stale-pr-label: "stale"
-        exempt-pr-labels: "pinned,security"
-        days-before-pr-stale: 30
-        days-before-pr-close: 7
-        ascending: true
-        operations-per-run: 100
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9
+        with:
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.
+
+          stale-pr-label: "stale"
+          exempt-pr-labels: "pinned,security"
+          days-before-pr-stale: 30
+          days-before-pr-close: 7
+          ascending: true
+          operations-per-run: 100

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,21 +8,17 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Git repository
-      uses: actions/checkout@v4
-
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        bundler-cache: true
-
-    - name: Set up Node
-      uses: actions/setup-node@v4
-
-    - name: Bootstrap
-      run: script/bootstrap
-      env:
-        SKIP_BUNDLER: true
-
-    - name: Tests
-      run: script/test
+      - name: Set up Git repository
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@cacc9f1c0b3f4eb8a16a6bb0ed10897b43b9de49 # v1
+        with:
+          bundler-cache: true
+      - name: Set up Node
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
+      - name: Bootstrap
+        run: script/bootstrap
+        env:
+          SKIP_BUNDLER: true
+      - name: Tests
+        run: script/test


### PR DESCRIPTION
Adhere to best security practices and use SHAs for GitHub Actions and not tags (they can be changed).

I used [`frizbee`](https://github.com/stacklok/frizbee) to do this.

```shell
brew install stacklok/tap/frizbee
frizbee ghactions -d .github/workflows/
```

- [x] Have you followed the [contributing guidelines](https://github.com/github/opensource.guide/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value to the Guides?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

-----
