### PR TITLE
Remove invalid media query

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,7 +2,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="google-site-verification" content="c1kuD-K2HIVF635lypcsWPoD4kilo5-jA_wBFyT4uMY" />
-  <link rel="icon" type="image/x-icon" href="https://github.githubassets.com/favicon.ico" media="(prefers-color-scheme:no-preference)">
+  <link rel="icon" type="image/x-icon" href="https://github.githubassets.com/favicon.ico">
   <link rel="icon" type="image/png" href="https://github.githubassets.com/favicons/favicon.png" media="(prefers-color-scheme:light)">
   <link rel="icon" type="image/png" href="https://github.githubassets.com/favicons/favicon-dark.png" media="(prefers-color-scheme:dark)">
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,300i,400,400i,700,700i" rel="stylesheet">


### PR DESCRIPTION
The value `no-preference` was never implemented by any browser and has been removed from the specification.

See https://www.w3.org/TR/mediaqueries-5/#prefers-color-scheme and https://github.com/w3c/csswg-drafts/issues/3857#issuecomment-634779976

- [x] Have you followed the [contributing guidelines](https://github.com/github/opensource.guide/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value to the Guides?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

-----
