### PR TITLE
Update nav.html

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -34,7 +34,7 @@
         {% endif %}
       </ul>
     </div>
-    {% if page.layout != 'index' %}
+    {% unless page.layout == 'index' %}
     <div class="float-sm-left pl-3 breadcrumb">
       <p class="my-0 py-3 py-sm-4 text-gray">
         {% if page.lang != 'en' %}


### PR DESCRIPTION
Using unless makes the condition slightly more readable by directly expressing the condition for the exception. In this case, we want to render the breadcrumb unless the layout is 'index', which reads more naturally and reduces cognitive load compared to checking if the layout is not 'index'. This refactor does not alter the behavior of the code but enhances its clarity and maintainability.
