### PR TITLE
Revert "chore(deps): bump rexml from 3.3.8 to 3.3.9 in the bundler group"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -294,7 +294,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.3.9)
+    rexml (3.3.8)
     rouge (3.30.0)
     ruby-rc4 (0.1.5)
     rubyzip (2.3.2)


### PR DESCRIPTION
Reverts github/opensource.guide#3328

dependabot/bundler/bundler-4415e84133