### PR TITLE
fix: link that is 403ing due to redirect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 .jekyll-metadata
 .ruby-version
+.tool-versions
 .sass-cache/
 /vendor
 _site/

--- a/script/html-proofer
+++ b/script/html-proofer
@@ -11,6 +11,7 @@ url_ignores = [
   "https://pages.18f.gov/open-source-guide/making-readmes-readable/",
   "https://foundation.mozilla.org/en/blog/its-a-wrap-movement-building-from-home/",
   "https://sloan.org/programs/digital-technology",
+  "https://www.jfklibrary.org/learn/education/teachers/curricular-resources/ask-not-what-your-country-can-do-for-you",
   %r{^https?://readwrite\.com/2014/10/10/open-source-diversity-how-to-contribute/},
   %r{^https?://twitter\.com/},
   %r{^https?://(www\.)?kickstarter\.com/},


### PR DESCRIPTION
- [x] added https://www.jfklibrary.org/learn/education/teachers/curricular-resources/ask-not-what-your-country-can-do-for-you to ignored link
- [x] add .tool-versions to .gitignore

- [ ] Have you followed the [contributing guidelines](https://github.com/github/opensource.guide/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you explained what your changes do, and why they add value to the Guides?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

-----
