### PR TITLE
chore: add rockwoodleadership urls to html_proofer ignores

### DIFF
--- a/script/html-proofer
+++ b/script/html-proofer
@@ -19,6 +19,7 @@ url_ignores = [
   %r{^https://help\.github\.com/},
   %r{^https://github\.com/},
   %r{^https?://(www\.)?reddit\.com},
+  %r{^https://rockwoodleadership\.org/},
 ]
 
 HTMLProofer::Runner.new(


### PR DESCRIPTION
- [x] Have you followed the [contributing guidelines](https://github.com/github/opensource.guide/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value to the Guides?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

-----

Currently PRs are failing tests because rockwoodleadership.com URLs are 403ing.