### PR TITLE
Update gitlab link, starred is no longer available in the explore interface

### DIFF
--- a/_articles/ar/how-to-contribute.md
+++ b/_articles/ar/how-to-contribute.md
@@ -232,7 +232,7 @@ related:
 * [First Contributions](https://firstcontributions.github.io)
 * [SourceSort](https://web.archive.org/web/20201111233803/https://www.sourcesort.com/)
 * [OpenSauced](https://opensauced.pizza/)
-* [GitLab Explore](https://gitlab.com/explore/projects/starred)
+* [GitLab Explore](https://gitlab.com/explore/projects/trending)
 
 ### قائمة تحقّق قبل أن تساهم {#قائمة-تحقّق-قبل-أن-تساهم}
 

--- a/_articles/how-to-contribute.md
+++ b/_articles/how-to-contribute.md
@@ -224,7 +224,7 @@ You can also use one of the following resources to help you discover and contrib
 * [First Contributions](https://firstcontributions.github.io)
 * [SourceSort](https://web.archive.org/web/20201111233803/https://www.sourcesort.com/)
 * [OpenSauced](https://opensauced.pizza/)
-* [GitLab Explore](https://gitlab.com/explore/projects/starred)
+* [GitLab Explore](https://gitlab.com/explore/projects/trending)
 
 ### A checklist before you contribute
 


### PR DESCRIPTION
As commit title says, this link was 403'ing, really a 404 - the starred option is no longer available on gitlab.com/explore , but there is a 'trending' category which is available without a login.

- [x] Have you followed the [contributing guidelines](https://github.com/github/opensource.guide/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value to the Guides?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

-----
