### PR TITLE
Restores underlines to links in the content

### DIFF
--- a/assets/css/custom.scss
+++ b/assets/css/custom.scss
@@ -283,3 +283,8 @@ blockquote {
    font-family: 'Vazirmatn', sans-serif;
   }
 }
+
+/* Restores underlines to links in the content. */
+article a {
+  text-decoration: revert;
+}


### PR DESCRIPTION
/assets/css/index.css has this code, which removes underlines from _all_ links on the page:
```
a {
  color: #0366d6;
  text-decoration: none;
}
```

I cannot find that file in the repo, so I've made my change to the custom.scss file.

This update reverts the underline removal for content links. Otherwise the links fail [SC 1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html) because, while the underline-on-hover style elsewhere suggests someone was trying to pass it via [Technique G183](https://www.w3.org/WAI/WCAG22/Techniques/general/G183), the contrast ratio between the blue link and black text is only 2.7:1.

This change fixes the WCAG violation and also provides demonstrably more usable links ("demonstrably" because I can point to research if needed).

- [x] Have you followed the [contributing guidelines](https://github.com/github/opensource.guide/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value to the Guides?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

-----
