### PR TITLE
fix heading capitalization consistency

### DIFF
--- a/_articles/accessibility-best-practices-for-your-project.md
+++ b/_articles/accessibility-best-practices-for-your-project.md
@@ -110,7 +110,7 @@ Documentation is often the first "UI" users touch. Make sure everyone can read i
 * Don't rely on color highlighting alone to indicate meaning.
 * Explain inline what the code does and what success looks like.
 
-## Design accessible Interfaces
+## Design Accessible Interfaces
 
 If your project has a web UI, these high-impact defaults will help all users.
 

--- a/_articles/accessibility-best-practices-for-your-project.md
+++ b/_articles/accessibility-best-practices-for-your-project.md
@@ -110,7 +110,7 @@ Documentation is often the first "UI" users touch. Make sure everyone can read i
 * Don't rely on color highlighting alone to indicate meaning.
 * Explain inline what the code does and what success looks like.
 
-## Design Accessible Interfaces
+## Design accessible interfaces
 
 If your project has a web UI, these high-impact defaults will help all users.
 


### PR DESCRIPTION
* [x] Have you followed the [[contributing guidelines](https://github.com/github/opensource.guide/blob/HEAD/CONTRIBUTING.md)](https://github.com/github/opensource.guide/blob/HEAD/CONTRIBUTING.md)?
* [x] Have you explained what your changes do, and why they add value to the Guides?

## Changes made

* Updated the heading capitalization from:
  `Design accessible Interfaces`
  to
  `Design Accessible Interfaces`

## Why this change?

This improves heading capitalization consistency and readability across the guide.