### PR TITLE
fix typo in accessibility workarounds text

### DIFF
--- a/_articles/accessibility-best-practices-for-your-project.md
+++ b/_articles/accessibility-best-practices-for-your-project.md
@@ -45,7 +45,7 @@ Add a clear statement that sets expectations and makes it easy for users to repo
 
 * State measurable goals (like [WCAG AA](https://www.w3.org/TR/WCAG22/#wcag-2-layers-of-guidance) where feasible).
 * Primary priorities, and how you meet them (keyboard and screen reader support, captions and transcripts, etc.).
-* Any known limitations, and alterative workarounds (if present).
+* Any known limitations, and alternative workarounds (if present).
 
 ### Contributor requirements
 


### PR DESCRIPTION
- [x] Have you followed the [contributing guidelines](https://github.com/github/opensource.guide/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value to the Guides?

I fixed a typo in the accessibility guide text:
alterative workarounds → alternative workarounds