### PR TITLE
remove bounties network and gitcoin links from how to get paid

### DIFF
--- a/_articles/getting-paid.md
+++ b/_articles/getting-paid.md
@@ -96,11 +96,6 @@ Depending on your personal circumstances, you can try raising money independentl
 * @gaearon funded his work on [Redux](https://github.com/reactjs/redux) through a [Patreon crowdfunding campaign](https://redux.js.org/)
 * @andrewgodwin funded work on Django schema migrations [through a Kickstarter campaign](https://www.kickstarter.com/projects/andrewgodwin/schema-migrations-for-django)
 
-Finally, sometimes open source projects put bounties on issues that you might consider helping with.
-
-* @ConnorChristie was able to get paid for [helping](https://web.archive.org/web/20181030123412/https://webcache.googleusercontent.com/search?strip=1&q=cache:https%3A%2F%2Fgithub.com%2FMARKETProtocol%2FMARKET.js%2Fissues%2F14) @MARKETProtocol work on their JavaScript library [through a bounty on gitcoin](https://gitcoin.co/).
-* @mamiM did Japanese translations for @MetaMask after the [issue was funded on Bounties Network](https://web.archive.org/web/20210902135755/https://explorer.bounties.network/bounty/134).
-
 ## Finding funding for your project
 
 Beyond arrangements for individual contributors, sometimes projects raise money from companies, individuals, or others to fund ongoing work.


### PR DESCRIPTION
- [x] Have you followed the [contributing guidelines](https://github.com/github/opensource.guide/blob/HEAD/CONTRIBUTING.md)?
- [x ] Have you explained what your changes do, and why they add value to the Guides?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

-----

Bounties Network has shut down, and gitcoin no longer does bounties. So these are better off not to be included or send people down a rabbit hole that no longer exists.
