### PR TITLE
Ignore peerj.com/preprints/1233 in link checker

### DIFF
--- a/script/html-proofer
+++ b/script/html-proofer
@@ -39,6 +39,7 @@ url_ignores = [
   "https://stackoverflow.com/questions/18664074/",
   "https://geekfeminism.fandom.com/wiki/Meritocracy",
   "https://news.ycombinator.com/item?id=7531689",
+  "https://peerj.com/preprints/1233/",
 
   # Regex patterns for broader ignore rules
   %r{^https?://stackoverflow\.com/questions/18664074/},


### PR DESCRIPTION
PeerJ returns 403 to GitHub Actions runners (likely Cloudflare bot detection), even though the URL resolves fine in a browser. This has been failing CI on recent PRs, e.g. https://github.com/github/opensource.guide/actions/runs/26646297579.

The link is cited in `_articles/building-community.md` (and all translations) supporting the claim that most projects only have one or two maintainers. The content is still valid, so adding it to the existing `url_ignores` list matches the pattern already used for other sites that block automated requests.