### PR TITLE
Gate Pages preview build/deploy to trusted authors

### DIFF
--- a/.github/workflows/jekyll-preview.yml
+++ b/.github/workflows/jekyll-preview.yml
@@ -1,65 +1,74 @@
-# # This workflow uses actions that are not certified by GitHub.
-# # They are provided by a third-party and are governed by
-# # separate terms of service, privacy policy, and support
-# # documentation.
-# 
-# # Sample workflow for building and deploying a Jekyll site to GitHub Pages
-# name: Deploy Jekyll site to Pages preview environment
-# on:
-#   # Runs on pull requests targeting the default branch
-#   pull_request_target:
-#     branches: ["main"]
-# # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-# permissions:
-#   contents: read
-#   pages: write
-#   id-token: write
-# # Allow only one concurrent deployment per PR, skipping runs queued between the run in-progress and latest queued.
-# # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
-# concurrency:
-#   group: "pages-preview @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
-#   cancel-in-progress: false
-# jobs:
-#   # Build job
-#   build:
-#     environment:
-#       name: "Pages Preview"
-#     # Limit permissions of the GITHUB_TOKEN for untrusted code
-#     permissions:
-#       contents: read
-#     runs-on: ubuntu-latest
-#     steps:
-#       - name: Checkout
-#         uses: actions/checkout@v6.0.2
-#         with:
-#           # For PRs make sure to checkout the PR branch
-#           ref: ${{ github.event.pull_request.head.sha }}
-#           repository: ${{ github.event.pull_request.head.repo.full_name }}
-#       - name: Setup Pages
-#         uses: actions/configure-pages@v6.0.0
-#       - name: Build with Jekyll
-#         uses: actions/jekyll-build-pages@44a6e6beabd48582f863aeeb6cb2151cc1716697 # v1
-#         with:
-#           source: ./
-#           destination: ./_site
-#       - name: Upload artifact
-#         # Automatically uploads an artifact from the './_site' directory by default
-#         uses: actions/upload-pages-artifact@v5.0.0
-#   # Deployment job
-#   deploy:
-#     environment:
-#       name: "Pages Preview"
-#       url: ${{ steps.deployment.outputs.page_url }}
-#     # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-#     permissions:
-#       contents: read
-#       pages: write
-#       id-token: write
-#     runs-on: ubuntu-latest
-#     needs: build
-#     steps:
-#       - name: Deploy to GitHub Pages
-#         id: deployment
-#         uses: actions/deploy-pages@v5.0.0
-#         with:
-#           preview: "true"
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+name: Deploy Jekyll site to Pages preview environment
+on:
+  # Runs on pull requests targeting the default branch
+  pull_request_target:
+    branches: ["main"]
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+# Allow only one concurrent deployment per PR, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages-preview @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  cancel-in-progress: false
+jobs:
+  # Build job
+  build:
+    # Only build/deploy PRs from trusted authors: this workflow checks out
+    # untrusted PR code and deploys it to a public preview domain.
+    # `author_association` is re-evaluated on every event and cannot be set by the
+    # PR author (unlike a label). To also allow previews for other contributors,
+    # add Required Reviewers to the "Pages Preview" environment rather than
+    # widening this condition.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository ||
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+    environment:
+      name: "Pages Preview"
+    # Limit permissions of the GITHUB_TOKEN for untrusted code
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          # For PRs make sure to checkout the PR branch
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - name: Setup Pages
+        uses: actions/configure-pages@v6.0.0
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@44a6e6beabd48582f863aeeb6cb2151cc1716697 # v1
+        with:
+          source: ./
+          destination: ./_site
+      - name: Upload artifact
+        # Automatically uploads an artifact from the './_site' directory by default
+        uses: actions/upload-pages-artifact@v5.0.0
+  # Deployment job
+  deploy:
+    environment:
+      name: "Pages Preview"
+      url: ${{ steps.deployment.outputs.page_url }}
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5.0.0
+        with:
+          preview: "true"

--- a/.github/workflows/jekyll-preview.yml
+++ b/.github/workflows/jekyll-preview.yml
@@ -15,7 +15,7 @@ permissions:
   pages: write
   id-token: write
 # Allow only one concurrent deployment per PR, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+# However, do NOT cancel in-progress runs as we want to allow these preview deployments to complete.
 concurrency:
   group: "pages-preview @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
   cancel-in-progress: false
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           # For PRs make sure to checkout the PR branch
           ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
## What
Re-enables the Pages preview workflow (temporarily disabled) and adds an author guard to the `build` job.

## Why
The workflow uses `pull_request_target` and checks out PR-author code, then builds and deploys it to a public preview domain. Without an author check, any fork PR can deploy attacker-controlled content to that GitHub-owned domain. The guard restricts automatic build/deploy to same-repo PRs and trusted authors (`OWNER`/`MEMBER`/`COLLABORATOR`). `author_association` is re-evaluated on every event and cannot be set by the PR author, so it is not subject to label-based bypasses.

`deploy` already declares `needs: build`, so gating `build` gates the whole chain.

## Recommended follow-up (repo setting)
For defense-in-depth — and to allow previews from other contributors via approval rather than skipping them — add **Required Reviewers** to the **Pages Preview** environment (Settings → Environments). It currently has only a branch policy.

## Notes
- Validated with `actionlint`.